### PR TITLE
Add Synchronous to MySqlConnectionStringBuilder.

### DIFF
--- a/src/MySqlConnector/MySqlClient/MySqlCommand.cs
+++ b/src/MySqlConnector/MySqlClient/MySqlCommand.cs
@@ -146,7 +146,7 @@ namespace MySql.Data.MySqlClient
 				var preparer = new MySqlStatementPreparer(CommandText, m_parameterCollection, connection.AllowUserVariables ? StatementPreparerOptions.AllowUserVariables : StatementPreparerOptions.None);
 				preparer.BindParameters();
 				var payload = new PayloadData(new ArraySegment<byte>(Payload.CreateEofStringPayload(CommandKind.Query, preparer.PreparedSql)));
-				await Session.SendAsync(payload, cancellationToken).ConfigureAwait(false);
+				await Connection.AdaptTask(Session.SendAsync(payload, cancellationToken)).ConfigureAwait(false);
 				reader = await MySqlDataReader.CreateAsync(this, behavior, cancellationToken).ConfigureAwait(false);
 				return reader;
 			}

--- a/src/MySqlConnector/MySqlClient/MySqlConnection.cs
+++ b/src/MySqlConnector/MySqlClient/MySqlConnection.cs
@@ -261,7 +261,7 @@ namespace MySql.Data.MySqlClient
 
 		internal ValueTask<T> AdaptTask<T>(ValueTask<T> task)
 		{
-			if (!Synchronous)
+			if (!Synchronous || task.IsCompletedSuccessfully)
 				return task;
 
 			return new ValueTask<T>(task.AsTask().GetAwaiter().GetResult());

--- a/src/MySqlConnector/MySqlClient/MySqlConnectionStringBuilder.cs
+++ b/src/MySqlConnector/MySqlClient/MySqlConnectionStringBuilder.cs
@@ -106,6 +106,12 @@ namespace MySql.Data.MySqlClient
 			set { MySqlConnectionStringOption.MaximumPoolSize.SetValue(this, value); }
 		}
 
+		public bool Synchronous
+		{
+			get { return MySqlConnectionStringOption.Synchronous.GetValue(this); }
+			set { MySqlConnectionStringOption.Synchronous.SetValue(this, value); }
+		}
+
 		public override bool ContainsKey(string key)
 		{
 			var option = MySqlConnectionStringOption.TryGetOptionForKey(key);
@@ -165,6 +171,7 @@ namespace MySql.Data.MySqlClient
 		public static readonly MySqlConnectionStringOption<bool> ConnectionReset;
 		public static readonly MySqlConnectionStringOption<uint> MinimumPoolSize;
 		public static readonly MySqlConnectionStringOption<uint> MaximumPoolSize;
+		public static readonly MySqlConnectionStringOption<bool> Synchronous;
 
 		public static MySqlConnectionStringOption TryGetOptionForKey(string key)
 		{
@@ -259,6 +266,10 @@ namespace MySql.Data.MySqlClient
 			AddOption(MaximumPoolSize = new MySqlConnectionStringOption<uint>(
 				keys: new[] { "Maximum Pool Size", "Max Pool Size", "MaximumPoolSize", "maxpoolsize" },
 				defaultValue: 100));
+
+			AddOption(Synchronous = new MySqlConnectionStringOption<bool>(
+				keys: new[] { "Synchronous" },
+				defaultValue: false));
 		}
 
 		static readonly Dictionary<string, MySqlConnectionStringOption> s_options;

--- a/src/MySqlConnector/MySqlClient/MySqlDataReader.cs
+++ b/src/MySqlConnector/MySqlClient/MySqlDataReader.cs
@@ -50,7 +50,7 @@ namespace MySql.Data.MySqlClient
 
 			if (m_state != State.AlreadyReadFirstRow)
 			{
-				var payloadTask = m_session.ReceiveReplyAsync(cancellationToken);
+				var payloadTask = Connection.AdaptTask(m_session.ReceiveReplyAsync(cancellationToken));
 				if (payloadTask.IsCompletedSuccessfully)
 					return ReadAsyncRemainder(payloadTask.Result) ? s_trueTask : s_falseTask;
 				return ReadAsyncAwaited(payloadTask.AsTask());
@@ -566,7 +566,7 @@ namespace MySql.Data.MySqlClient
 		{
 			while (true)
 			{
-				var payload = await m_session.ReceiveReplyAsync(cancellationToken).ConfigureAwait(false);
+				var payload = await Connection.AdaptTask(m_session.ReceiveReplyAsync(cancellationToken)).ConfigureAwait(false);
 
 				var firstByte = payload.HeaderByte;
 				if (firstByte == OkPayload.Signature)
@@ -593,11 +593,11 @@ namespace MySql.Data.MySqlClient
 
 					for (var column = 0; column < m_columnDefinitions.Length; column++)
 					{
-						payload = await m_session.ReceiveReplyAsync(cancellationToken).ConfigureAwait(false);
+						payload = await Connection.AdaptTask(m_session.ReceiveReplyAsync(cancellationToken)).ConfigureAwait(false);
 						m_columnDefinitions[column] = ColumnDefinitionPayload.Create(payload);
 					}
 
-					payload = await m_session.ReceiveReplyAsync(cancellationToken).ConfigureAwait(false);
+					payload = await Connection.AdaptTask(m_session.ReceiveReplyAsync(cancellationToken)).ConfigureAwait(false);
 					EofPayload.Create(payload);
 
 					m_command.LastInsertedId = -1;


### PR DESCRIPTION
This initial implementation could have adverse affects on performance, so you might not want to merge, but it is an idea for enforcing synchronous access, even when using the async methods, to improve debugging.