### PR TITLE
Fix Connection Pool

### DIFF
--- a/src/MySqlConnector/MySqlClient/ConnectionPool.cs
+++ b/src/MySqlConnector/MySqlClient/ConnectionPool.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using MySql.Data.Serialization;
@@ -7,64 +8,211 @@ namespace MySql.Data.MySqlClient
 {
 	internal sealed class ConnectionPool
 	{
-		public async Task<MySqlSession> TryGetSessionAsync(CancellationToken cancellationToken)
+		public async Task<MySqlSession> GetSessionAsync(CancellationToken cancellationToken)
 		{
-			try
-			{
-				await m_semaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
+			AssertInvariants();
 
-				if (m_sessions.Count > 0)
-					return m_sessions.Dequeue();
-			}
-			finally
+			using (cancellationToken.Register(() =>
 			{
-				m_semaphore.Release();
+				// wake up all waiting threads if the cancellation token is cancelled
+				lock (m_lock)
+					Monitor.PulseAll(m_lock);
+			}))
+			{
+				MySqlSession temporarySession = null;
+
+				try
+				{
+					// keep looping until cancelled (timeout) or a session is retrieved
+					while (true)
+					{
+						cancellationToken.ThrowIfCancellationRequested();
+
+						bool isNew;
+						AssertInvariants();
+
+						// grab an idle session, or take an available session, or block
+						lock (m_lock)
+						{
+							if (m_idleSessions.Count > 0)
+							{
+								temporarySession = m_idleSessions.Dequeue();
+								isNew = false;
+								m_temporary++;
+							}
+							else if (m_available > 0)
+							{
+								temporarySession = new MySqlSession(this);
+								isNew = true;
+								m_temporary++;
+								m_available--;
+							}
+							else
+							{
+								Monitor.Wait(m_lock);
+								continue;
+							}
+						}
+						AssertInvariants();
+
+						// asynchronously connect the session or verify that an idle session is valid
+						bool isValid;
+						if (isNew)
+						{
+							await temporarySession.ConnectAsync(m_server.Split(','), m_port, m_userId, m_password, m_database, cancellationToken).ConfigureAwait(false);
+							isValid = true;
+						}
+						else
+						{
+							isValid = await TryActivateIdleSessionAsync(temporarySession, cancellationToken).ConfigureAwait(false);
+						}
+
+						// if valid, return it
+						if (isValid)
+						{
+							lock (m_lock)
+							{
+								m_activeSessions.Add(temporarySession);
+								m_temporary--;
+
+								var session = temporarySession;
+								temporarySession = null;
+								return session;
+							}
+						}
+
+						// destroy this invalid temporary session and try again
+						lock (m_lock)
+						{
+							m_temporary--;
+							m_available++;
+							temporarySession = null;
+
+							Monitor.Pulse(m_lock);
+						}
+					}
+				}
+				catch
+				{
+					// clean up any local temporary session upon exception
+					lock (m_lock)
+					{
+						if (temporarySession != null)
+						{
+							m_temporary--;
+							m_available++;
+							Monitor.Pulse(m_lock);
+						}
+					}
+					throw;
+				}
+				finally
+				{
+					AssertInvariants();
+				}
 			}
-			return null;
 		}
 
-		public bool Return(MySqlSession session)
+		private async Task<bool> TryActivateIdleSessionAsync(MySqlSession session, CancellationToken cancellationToken)
 		{
-			try
+			// test that session is still valid and (optionally) reset it
+			if (!await session.TryPingAsync(cancellationToken).ConfigureAwait(false))
 			{
-				m_semaphore.Wait();
+				await session.DisposeAsync(cancellationToken).ConfigureAwait(false);
+				return false;
+			}
 
-				// TODO: Dispose oldest connections in the pool first?
-				if (m_sessions.Count >= m_maximumSize)
-					return false;
-				m_sessions.Enqueue(session);
-				return true;
-			}
-			finally
+			if (m_resetConnections)
+				await session.ResetConnectionAsync(m_userId, m_password, m_database, cancellationToken).ConfigureAwait(false);
+			return true;
+		}
+		
+		public void Return(MySqlSession session)
+		{
+			AssertInvariants();
+
+			lock (m_lock)
 			{
-				m_semaphore.Release();
+				if (!m_activeSessions.Remove(session))
+					throw new InvalidOperationException("Returned session wasn't active.");
+				m_temporary++;
 			}
+
+			AssertInvariants();
+			
+			if (m_closeOnReturn)
+			{
+				session.DisposeAsync(CancellationToken.None).GetAwaiter().GetResult();
+				lock (m_lock)
+				{
+					m_temporary--;
+					m_available++;
+					Monitor.Pulse(m_lock);
+				}
+			}
+			else
+			{
+				lock (m_lock)
+				{
+					m_temporary--;
+					m_idleSessions.Enqueue(session);
+					Monitor.Pulse(m_lock);
+				}
+			}
+			
+			AssertInvariants();
 		}
 
 		public async Task ClearAsync(CancellationToken cancellationToken)
 		{
-			try
+			AssertInvariants();
+
+			while (!cancellationToken.IsCancellationRequested)
 			{
-				await m_semaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
+				MySqlSession session = null;
 
-				while (m_sessions.Count > 0)
+				// get one idle session at a time and clean it up
+				AssertInvariants();
+				lock (m_lock)
 				{
-					cancellationToken.ThrowIfCancellationRequested();
+					if (m_idleSessions.Count > 0)
+					{
+						session = m_idleSessions.Dequeue();
+						m_temporary++;
+					}
+				}
+				AssertInvariants();
 
-					var session = m_sessions.Dequeue();
+				if (session == null)
+					break;
+
+				try
+				{
 					await session.DisposeAsync(cancellationToken).ConfigureAwait(false);
 				}
+				catch (OperationCanceledException)
+				{
+				}
+				finally
+				{
+					AssertInvariants();
+					lock (m_lock)
+					{
+						m_temporary--;
+						m_available++;
+						Monitor.Pulse(m_lock);
+					}
+					AssertInvariants();
+				}
 			}
-			finally
-			{
-				m_semaphore.Release();
-			}
+
+			AssertInvariants();
 		}
 
 		public static ConnectionPool GetPool(MySqlConnectionStringBuilder csb)
 		{
 			if (!csb.Pooling)
-				return null;
+				return new ConnectionPool(csb.Server, (int) csb.Port, csb.UserID, csb.Password, csb.Database, csb.ConnectionReset, true, 0, 1);
 
 			string key = csb.ConnectionString;
 			lock (s_lock)
@@ -72,7 +220,7 @@ namespace MySql.Data.MySqlClient
 				ConnectionPool pool;
 				if (!s_pools.TryGetValue(key, out pool))
 				{
-					pool = new ConnectionPool((int) csb.MinimumPoolSize, (int) csb.MaximumPoolSize);
+					pool = new ConnectionPool(csb.Server, (int) csb.Port, csb.UserID, csb.Password, csb.Database, csb.ConnectionReset, false, (int) csb.MinimumPoolSize, (int) csb.MaximumPoolSize);
 					s_pools.Add(key, pool);
 				}
 				return pool;
@@ -89,20 +237,56 @@ namespace MySql.Data.MySqlClient
 				await pool.ClearAsync(cancellationToken).ConfigureAwait(false);
 		}
 
-		private ConnectionPool(int minimumSize, int maximumSize)
+		private ConnectionPool(string server, int port, string userId, string password, string database, bool resetConnections, bool closeOnReturn, int minimumSize, int maximumSize)
 		{
-			m_semaphore = new SemaphoreSlim(1, 1);
-			m_sessions = new Queue<MySqlSession>();
+			m_server = server;
+			m_port = port;
+			m_userId = userId;
+			m_password = password;
+			m_database = database;
+			m_resetConnections = resetConnections;
+			m_closeOnReturn = closeOnReturn;
 			m_minimumSize = minimumSize;
 			m_maximumSize = maximumSize;
+
+			m_lock = new object();
+
+			m_idleSessions = new Queue<MySqlSession>();
+			m_activeSessions = new List<MySqlSession>();
+			m_available = m_maximumSize;
+			AssertInvariants();
+		}
+
+		private void AssertInvariants()
+		{
+			lock (m_lock)
+			{
+				// This invariant must always hold outside of the lock: the following values must sum to `m_maximumSize`:
+				//   - m_activeSessions.Count: the number of sessions that are held by clients
+				//   - m_idleSessions.Count: the number of sessions that have been returned to the pool and are idle
+				//   - m_available: the number of sessions available to be created
+				//   - m_temporary: the number of sessions actively in use by code in this class; these will soon be added to one of the other categories
+				if (m_activeSessions.Count + m_idleSessions.Count + m_available + m_temporary != m_maximumSize)
+					throw new InvalidOperationException("Invalid: Active:{0} Idle:{1} Avail:{2} Temp:{3} Max:{4}".FormatInvariant(m_activeSessions.Count, m_idleSessions.Count, m_available, m_temporary, m_maximumSize));
+			}
 		}
 
 		static readonly object s_lock = new object();
 		static readonly Dictionary<string, ConnectionPool> s_pools = new Dictionary<string, ConnectionPool>();
 
-		readonly SemaphoreSlim m_semaphore;
-		readonly Queue<MySqlSession> m_sessions;
+		readonly string m_server;
+		readonly int m_port;
+		readonly string m_userId;
+		readonly string m_password;
+		readonly string m_database;
+		readonly bool m_resetConnections;
+		readonly bool m_closeOnReturn;
 		readonly int m_minimumSize;
 		readonly int m_maximumSize;
+		readonly object m_lock;
+		readonly List<MySqlSession> m_activeSessions;
+		readonly Queue<MySqlSession> m_idleSessions;
+		int m_available;
+		int m_temporary;
 	}
 }

--- a/src/MySqlConnector/MySqlClient/ConnectionPool.cs
+++ b/src/MySqlConnector/MySqlClient/ConnectionPool.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
@@ -8,306 +9,155 @@ namespace MySql.Data.MySqlClient
 {
 	internal sealed class ConnectionPool
 	{
+
 		public async Task<MySqlSession> GetSessionAsync(CancellationToken cancellationToken)
 		{
-			AssertInvariants();
+			cancellationToken.ThrowIfCancellationRequested();
 
-			MySqlSession temporarySession = null;
+			// if the drain lock is held, connection draining is in progress
+			await m_drain_lock.WaitAsync(cancellationToken).ConfigureAwait(false);
+			m_drain_lock.Release();
 
+			// wait for an open slot
+			await m_session_semaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
 			try
 			{
-				// keep looping until cancelled (timeout) or a session is retrieved
-				while (true)
+				MySqlSession session;
+				// check for a pooled session
+				if (m_sessions.TryDequeue(out session))
 				{
-					cancellationToken.ThrowIfCancellationRequested();
-
-					bool isNew = false;
-					AssertInvariants();
-
-					// grab an idle session or take an available session
-					using (await AcquireLockAsync(cancellationToken).ConfigureAwait(false))
+					if (!await session.TryPingAsync(cancellationToken).ConfigureAwait(false))
 					{
-						if (m_idleSessions.Count > 0)
-						{
-							temporarySession = m_idleSessions.Dequeue();
-							isNew = false;
-							m_temporary++;
-						}
-						else if (m_available > 0)
-						{
-							temporarySession = new MySqlSession(this);
-							isNew = true;
-							m_temporary++;
-							m_available--;
-						}
-					}
-
-					if (temporarySession == null)
-					{
-						// no sessions available, try again soon
-						await Task.Delay(TimeSpan.FromMilliseconds(50), cancellationToken).ConfigureAwait(false);
-						continue;
-					}
-
-					AssertInvariants();
-
-					// asynchronously connect the session or verify that an idle session is valid
-					bool isValid;
-					if (isNew)
-					{
-						await temporarySession.ConnectAsync(m_server.Split(','), m_port, m_userId, m_password, m_database, cancellationToken).ConfigureAwait(false);
-						isValid = true;
+						// session is not valid
+						await session.DisposeAsync(cancellationToken).ConfigureAwait(false);
 					}
 					else
 					{
-						isValid = await TryActivateIdleSessionAsync(temporarySession, cancellationToken).ConfigureAwait(false);
-					}
-
-					// if valid, return it
-					if (isValid)
-					{
-						using (await AcquireLockAsync(cancellationToken).ConfigureAwait(false))
+						// session is valid, reset if supported
+						if (m_resetConnections)
 						{
-							m_activeSessions.Add(temporarySession);
-							m_temporary--;
-
-							var session = temporarySession;
-							temporarySession = null;
-							return session;
+							await session.ResetConnectionAsync(m_userId, m_password, m_database, cancellationToken).ConfigureAwait(false);
 						}
-					}
-
-					// destroy this invalid temporary session and try again
-					using (await AcquireLockAsync(cancellationToken).ConfigureAwait(false))
-					{
-						m_temporary--;
-						m_available++;
-						temporarySession = null;
+						// pooled session is ready to be used; return it
+						return session;
 					}
 				}
+
+				session = new MySqlSession(this);
+				await session.ConnectAsync(m_servers, m_port, m_userId, m_password, m_database, m_connectionTimeout, cancellationToken).ConfigureAwait(false);
+				return session;
 			}
 			catch
 			{
-				// clean up any local temporary session upon exception
-				using (await AcquireLockAsync(cancellationToken).ConfigureAwait(false))
-				{
-					if (temporarySession != null)
-					{
-						m_temporary--;
-						m_available++;
-					}
-				}
+				m_session_semaphore.Release();
 				throw;
+			}
+		}
+
+		public void Return(MySqlSession session)
+		{
+			try
+			{
+				m_sessions.Enqueue(session);
 			}
 			finally
 			{
-				AssertInvariants();
+				m_session_semaphore.Release();
 			}
-		}
-
-		private async Task<bool> TryActivateIdleSessionAsync(MySqlSession session, CancellationToken cancellationToken)
-		{
-			// test that session is still valid and (optionally) reset it
-			if (!await session.TryPingAsync(cancellationToken).ConfigureAwait(false))
-			{
-				await session.DisposeAsync(cancellationToken).ConfigureAwait(false);
-				return false;
-			}
-
-			if (m_resetConnections)
-				await session.ResetConnectionAsync(m_userId, m_password, m_database, cancellationToken).ConfigureAwait(false);
-			return true;
-		}
-		
-		public void Return(MySqlSession session)
-		{
-			AssertInvariants();
-
-			using (AcquireLock(CancellationToken.None))
-			{
-				if (!m_activeSessions.Remove(session))
-					throw new InvalidOperationException("Returned session wasn't active.");
-				m_temporary++;
-			}
-
-			AssertInvariants();
-			
-			if (m_closeOnReturn)
-			{
-				session.DisposeAsync(CancellationToken.None).GetAwaiter().GetResult();
-				using (AcquireLock(CancellationToken.None))
-				{
-					m_temporary--;
-					m_available++;
-				}
-			}
-			else
-			{
-				using (AcquireLock(CancellationToken.None))
-				{
-					m_temporary--;
-					m_idleSessions.Enqueue(session);
-				}
-			}
-
-			AssertInvariants();
 		}
 
 		public async Task ClearAsync(CancellationToken cancellationToken)
 		{
-			AssertInvariants();
-
-			while (!cancellationToken.IsCancellationRequested)
+			cancellationToken.ThrowIfCancellationRequested();
+			try
 			{
-				MySqlSession session = null;
+				// don't let any new connections out of the pool
+				await m_drain_lock.WaitAsync(cancellationToken).ConfigureAwait(false);
 
-				// get one idle session at a time and clean it up
-				AssertInvariants();
-				using (await AcquireLockAsync(cancellationToken).ConfigureAwait(false))
+				// acquire all of the session slots
+				for (var i = 0; i < m_maximumSize; i++)
 				{
-					if (m_idleSessions.Count > 0)
+					await m_session_semaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
+
+					// clear all of the existing sessions
+					var tasks = new List<Task>();
+					MySqlSession session;
+					while (m_sessions.TryDequeue(out session))
 					{
-						session = m_idleSessions.Dequeue();
-						m_temporary++;
+						tasks.Add(session.DisposeAsync(cancellationToken));
 					}
-				}
-				AssertInvariants();
-
-				if (session == null)
-					break;
-
-				try
-				{
-					await session.DisposeAsync(cancellationToken).ConfigureAwait(false);
-				}
-				catch (OperationCanceledException)
-				{
-				}
-				finally
-				{
-					AssertInvariants();
-					using (await AcquireLockAsync(cancellationToken).ConfigureAwait(false))
+					if (tasks.Count > 0)
 					{
-						m_temporary--;
-						m_available++;
+						await Task.WhenAll(tasks).ConfigureAwait(false);
 					}
-					AssertInvariants();
 				}
 			}
+			finally
+			{
+				// release all of the session slots
+				m_session_semaphore.Release(m_maximumSize);
 
-			AssertInvariants();
+				// release the master lock
+				m_drain_lock.Release();
+			}
 		}
 
 		public static ConnectionPool GetPool(MySqlConnectionStringBuilder csb)
 		{
 			if (!csb.Pooling)
-				return new ConnectionPool(csb.Server, (int) csb.Port, csb.UserID, csb.Password, csb.Database, csb.ConnectionReset, true, 0, 1);
+				return null;
 
-			string key = csb.ConnectionString;
-			lock (s_lock)
+			var key = csb.ConnectionString;
+
+			ConnectionPool pool;
+			if (!s_pools.TryGetValue(key, out pool))
 			{
-				ConnectionPool pool;
-				if (!s_pools.TryGetValue(key, out pool))
-				{
-					pool = new ConnectionPool(csb.Server, (int) csb.Port, csb.UserID, csb.Password, csb.Database, csb.ConnectionReset, false, (int) csb.MinimumPoolSize, (int) csb.MaximumPoolSize);
-					s_pools.Add(key, pool);
-				}
-				return pool;
+				pool = s_pools.GetOrAdd(key, new ConnectionPool(csb.Server.Split(','), (int) csb.Port, csb.UserID,
+						csb.Password, csb.Database, (int) csb.ConnectionTimeout, csb.ConnectionReset, (int)csb.MinimumPoolSize, (int) csb.MaximumPoolSize));
 			}
+			return pool;
 		}
 
 		public static async Task ClearPoolsAsync(CancellationToken cancellationToken)
 		{
-			List<ConnectionPool> pools;
-			lock (s_lock)
-				pools = new List<ConnectionPool>(s_pools.Values);
+			var pools = new List<ConnectionPool>(s_pools.Values);
 
 			foreach (var pool in pools)
 				await pool.ClearAsync(cancellationToken).ConfigureAwait(false);
 		}
 
-		private ConnectionPool(string server, int port, string userId, string password, string database, bool resetConnections, bool closeOnReturn, int minimumSize, int maximumSize)
+		private ConnectionPool(IEnumerable<string> servers, int port, string userId, string password, string database, int connectionTimeout,
+				bool resetConnections, int minimumSize, int maximumSize)
 		{
-			m_server = server;
+			m_servers = servers;
 			m_port = port;
 			m_userId = userId;
 			m_password = password;
 			m_database = database;
+			m_connectionTimeout = connectionTimeout;
 			m_resetConnections = resetConnections;
-			m_closeOnReturn = closeOnReturn;
 			m_minimumSize = minimumSize;
 			m_maximumSize = maximumSize;
 
-			m_lock = new SemaphoreSlim(1, 1);
-
-			m_idleSessions = new Queue<MySqlSession>();
-			m_activeSessions = new List<MySqlSession>();
-			m_available = m_maximumSize;
-			AssertInvariants();
+			m_drain_lock = new SemaphoreSlim(1);
+			m_session_semaphore = new SemaphoreSlim(m_maximumSize);
+			m_sessions = new ConcurrentQueue<MySqlSession>();
 		}
 
-		private void AssertInvariants()
-		{
-			using (AcquireLock(CancellationToken.None))
-			{
-				// This invariant must always hold outside of the lock: the following values must sum to `m_maximumSize`:
-				//   - m_activeSessions.Count: the number of sessions that are held by clients
-				//   - m_idleSessions.Count: the number of sessions that have been returned to the pool and are idle
-				//   - m_available: the number of sessions available to be created
-				//   - m_temporary: the number of sessions actively in use by code in this class; these will soon be added to one of the other categories
-				if (m_activeSessions.Count + m_idleSessions.Count + m_available + m_temporary != m_maximumSize)
-					throw new InvalidOperationException("Invalid: Active:{0} Idle:{1} Avail:{2} Temp:{3} Max:{4}".FormatInvariant(m_activeSessions.Count, m_idleSessions.Count, m_available, m_temporary, m_maximumSize));
-			}
-		}
+		static readonly ConcurrentDictionary<string, ConnectionPool> s_pools = new ConcurrentDictionary<string, ConnectionPool>();
 
+		readonly SemaphoreSlim m_drain_lock;
+		readonly SemaphoreSlim m_session_semaphore;
+		readonly ConcurrentQueue<MySqlSession> m_sessions;
 
-		private LockReleaser AcquireLock(CancellationToken cancellationToken)
-		{
-			m_lock.Wait(cancellationToken);
-			return new LockReleaser(m_lock);
-		}
-
-		private async Task<LockReleaser> AcquireLockAsync(CancellationToken cancellationToken)
-		{
-			await m_lock.WaitAsync(cancellationToken).ConfigureAwait(false);
-			return new LockReleaser(m_lock);
-		}
-
-		private sealed class LockReleaser : IDisposable
-		{
-			public LockReleaser(SemaphoreSlim semaphore)
-			{
-				m_lock = semaphore;
-			}
-
-			public void Dispose()
-			{
-				if (m_lock != null)
-				{
-					m_lock.Release();
-					m_lock = null;
-				}
-			}
-
-			SemaphoreSlim m_lock;
-		}
-
-		static readonly object s_lock = new object();
-		static readonly Dictionary<string, ConnectionPool> s_pools = new Dictionary<string, ConnectionPool>();
-
-		readonly string m_server;
+		readonly IEnumerable<string> m_servers;
 		readonly int m_port;
 		readonly string m_userId;
 		readonly string m_password;
 		readonly string m_database;
+		readonly int m_connectionTimeout;
 		readonly bool m_resetConnections;
-		readonly bool m_closeOnReturn;
 		readonly int m_minimumSize;
 		readonly int m_maximumSize;
-		readonly SemaphoreSlim m_lock;
-		readonly List<MySqlSession> m_activeSessions;
-		readonly Queue<MySqlSession> m_idleSessions;
-		int m_available;
-		int m_temporary;
 	}
 }

--- a/src/MySqlConnector/MySqlClient/MySqlConnection.cs
+++ b/src/MySqlConnector/MySqlClient/MySqlConnection.cs
@@ -1,9 +1,7 @@
 ﻿using System;
 using System.Data;
 using System.Data.Common;
-using System.IO;
 using System.Net.Sockets;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using MySql.Data.Serialization;
@@ -105,35 +103,17 @@ namespace MySql.Data.MySqlClient
 				if (m_session != null)
 				{
 					// test that session is still valid and (optionally) reset it
-					if (!await TryPingAsync(m_session, cancellationToken).ConfigureAwait(false))
+					if (!await m_session.TryPingAsync(cancellationToken).ConfigureAwait(false))
 						Utility.Dispose(ref m_session);
 					else if (m_connectionStringBuilder.ConnectionReset)
-						await ResetConnectionAsync(cancellationToken).ConfigureAwait(false);
+						await m_session.ResetConnectionAsync(m_connectionStringBuilder.UserID, m_connectionStringBuilder.Password, m_database, cancellationToken).ConfigureAwait(false);
 				}
 
 				if (m_session == null)
 				{
 					m_session = new MySqlSession(pool);
-					var connected = await m_session.ConnectAsync(m_connectionStringBuilder.Server.Split(','), (int) m_connectionStringBuilder.Port).ConfigureAwait(false);
-					if (!connected)
-					{
-						SetState(ConnectionState.Closed);
-						throw new MySqlException("Unable to connect to any of the specified MySQL hosts.");
-					}
-
-					var payload = await m_session.ReceiveAsync(cancellationToken).ConfigureAwait(false);
-					var reader = new ByteArrayReader(payload.ArraySegment.Array, payload.ArraySegment.Offset, payload.ArraySegment.Count);
-					var initialHandshake = new InitialHandshakePacket(reader);
-					if (initialHandshake.AuthPluginName != "mysql_native_password")
-						throw new NotSupportedException("Only 'mysql_native_password' authentication method is supported.");
-					m_session.ServerVersion = new ServerVersion(Encoding.ASCII.GetString(initialHandshake.ServerVersion));
-					m_session.AuthPluginData = initialHandshake.AuthPluginData;
-
-					var response = HandshakeResponse41Packet.Create(initialHandshake, m_connectionStringBuilder.UserID, m_connectionStringBuilder.Password, m_database);
-					payload = new PayloadData(new ArraySegment<byte>(response));
-					await m_session.SendReplyAsync(payload, cancellationToken).ConfigureAwait(false);
-					await m_session.ReceiveReplyAsync(cancellationToken).ConfigureAwait(false);
-					// TODO: Check success
+					await m_session.ConnectAsync(m_connectionStringBuilder.Server.Split(','), (int) m_connectionStringBuilder.Port, m_connectionStringBuilder.UserID,
+						m_connectionStringBuilder.Password, m_database, cancellationToken).ConfigureAwait(false);
 				}
 
 				m_hasBeenOpened = true;
@@ -272,55 +252,6 @@ namespace MySql.Data.MySqlClient
 				}
 				SetState(ConnectionState.Closed);
 			}
-		}
-
-		private async Task ResetConnectionAsync(CancellationToken cancellationToken)
-		{
-			if (m_session.ServerVersion.Version.CompareTo(ServerVersions.SupportsResetConnection) >= 0)
-			{
-				await m_session.SendAsync(ResetConnectionPayload.Create(), cancellationToken).ConfigureAwait(false);
-				var payload = await m_session.ReceiveReplyAsync(cancellationToken).ConfigureAwait(false);
-				OkPayload.Create(payload);
-			}
-			else
-			{
-				// optimistically hash the password with the challenge from the initial handshake (supported by MariaDB; doesn't appear to be supported by MySQL)
-				var hashedPassword = AuthenticationUtility.HashPassword(m_session.AuthPluginData, 0, m_connectionStringBuilder.Password);
-				var payload = ChangeUserPayload.Create(m_connectionStringBuilder.UserID, hashedPassword, m_database);
-				await m_session.SendAsync(payload, cancellationToken).ConfigureAwait(false);
-				payload = await m_session.ReceiveReplyAsync(cancellationToken).ConfigureAwait(false);
-				if (payload.HeaderByte == AuthenticationMethodSwitchRequestPayload.Signature)
-				{
-					// if the server didn't support the hashed password; rehash with the new challenge
-					var switchRequest = AuthenticationMethodSwitchRequestPayload.Create(payload);
-					if (switchRequest.Name != "mysql_native_password")
-						throw new NotSupportedException("Only 'mysql_native_password' authentication method is supported.");
-					hashedPassword = AuthenticationUtility.HashPassword(switchRequest.Data, 0, m_connectionStringBuilder.Password);
-					payload = new PayloadData(new ArraySegment<byte>(hashedPassword));
-					await m_session.SendReplyAsync(payload, cancellationToken).ConfigureAwait(false);
-					payload = await m_session.ReceiveReplyAsync(cancellationToken).ConfigureAwait(false);
-				}
-				OkPayload.Create(payload);
-			}
-		}
-
-		private static async Task<bool> TryPingAsync(MySqlSession session, CancellationToken cancellationToken)
-		{
-			await session.SendAsync(PingPayload.Create(), cancellationToken).ConfigureAwait(false);
-			try
-			{
-				var payload = await session.ReceiveReplyAsync(cancellationToken).ConfigureAwait(false);
-				OkPayload.Create(payload);
-				return true;
-			}
-			catch (EndOfStreamException)
-			{
-			}
-			catch (SocketException)
-			{
-			}
-
-			return false;
 		}
 
 		MySqlConnectionStringBuilder m_connectionStringBuilder;

--- a/src/MySqlConnector/MySqlClient/MySqlConnectionStringBuilder.cs
+++ b/src/MySqlConnector/MySqlClient/MySqlConnectionStringBuilder.cs
@@ -94,6 +94,12 @@ namespace MySql.Data.MySqlClient
 			set { MySqlConnectionStringOption.ConnectionReset.SetValue(this, value); }
 		}
 
+		public uint ConnectionTimeout
+		{
+			get { return MySqlConnectionStringOption.ConnectionTimeout.GetValue(this); }
+			set { MySqlConnectionStringOption.ConnectionTimeout.SetValue(this, value); }
+		}
+
 		public uint MinimumPoolSize
 		{
 			get { return MySqlConnectionStringOption.MinimumPoolSize.GetValue(this); }
@@ -169,6 +175,7 @@ namespace MySql.Data.MySqlClient
 		public static readonly MySqlConnectionStringOption<bool> UseCompression;
 		public static readonly MySqlConnectionStringOption<bool> Pooling;
 		public static readonly MySqlConnectionStringOption<bool> ConnectionReset;
+		public static readonly MySqlConnectionStringOption<uint> ConnectionTimeout;
 		public static readonly MySqlConnectionStringOption<uint> MinimumPoolSize;
 		public static readonly MySqlConnectionStringOption<uint> MaximumPoolSize;
 		public static readonly MySqlConnectionStringOption<bool> UseAffectedRows;
@@ -258,6 +265,10 @@ namespace MySql.Data.MySqlClient
 			AddOption(ConnectionReset = new MySqlConnectionStringOption<bool>(
 				keys: new[] { "Connection Reset", "ConnectionReset" },
 				defaultValue: true));
+
+			AddOption(ConnectionTimeout = new MySqlConnectionStringOption<uint>(
+				keys: new[] { "Connection Timeout", "ConnectionTimeout", "Connect Timeout" },
+				defaultValue: 15u));
 
 			AddOption(MinimumPoolSize = new MySqlConnectionStringOption<uint>(
 				keys: new[] { "Minimum Pool Size", "Min Pool Size", "MinimumPoolSize", "minpoolsize" },

--- a/src/MySqlConnector/Serialization/MySqlSession.cs
+++ b/src/MySqlConnector/Serialization/MySqlSession.cs
@@ -20,7 +20,8 @@ namespace MySql.Data.Serialization
 		public ServerVersion ServerVersion { get; set; }
 		public byte[] AuthPluginData { get; set; }
 		public ConnectionPool Pool { get; }
-		public void ReturnToPool() => Pool.Return(this);
+
+		public void ReturnToPool() => Pool?.Return(this);
 
 		public async Task DisposeAsync(CancellationToken cancellationToken)
 		{
@@ -53,9 +54,9 @@ namespace MySql.Data.Serialization
 			m_state = State.Closed;
 		}
 
-		public async Task ConnectAsync(IEnumerable<string> hosts, int port, string userId, string password, string database, CancellationToken cancellationToken)
+		public async Task ConnectAsync(IEnumerable<string> hosts, int port, string userId, string password, string database, int timeoutSeconds, CancellationToken cancellationToken)
 		{
-			var connected = await OpenSocketAsync(hosts, port, cancellationToken).ConfigureAwait(false);
+			var connected = await OpenSocketAsync(hosts, port, timeoutSeconds).ConfigureAwait(false);
 			if (!connected)
 				throw new MySqlException("Unable to connect to any of the specified MySQL hosts.");
 
@@ -146,8 +147,13 @@ namespace MySql.Data.Serialization
 				throw new InvalidOperationException("MySqlSession is not connected.");
 		}
 
-		private async Task<bool> OpenSocketAsync(IEnumerable<string> hostnames, int port, CancellationToken cancellationToken)
+		private async Task<bool> OpenSocketAsync(IEnumerable<string> hostnames, int port, int timeoutSeconds)
 		{
+			DateTime? connectTimeout = null;
+			if (timeoutSeconds > 0)
+			{
+				connectTimeout = DateTime.UtcNow + TimeSpan.FromSeconds(timeoutSeconds);
+			}
 			foreach (var hostname in hostnames)
 			{
 				IPAddress[] ipAddresses;
@@ -164,41 +170,44 @@ namespace MySql.Data.Serialization
 				// need to try IP Addresses one at a time: https://github.com/dotnet/corefx/issues/5829
 				foreach (var ipAddress in ipAddresses)
 				{
-					cancellationToken.ThrowIfCancellationRequested();
-
-					Socket socket = null;
+					var socket = new Socket(ipAddress.AddressFamily, SocketType.Stream, ProtocolType.Tcp);
 					try
 					{
-						socket = new Socket(ipAddress.AddressFamily, SocketType.Stream, ProtocolType.Tcp);
-						using (cancellationToken.Register(() => socket.Dispose()))
+						var connectTasks = new List<Task>
 						{
-							try
-							{
 #if NETSTANDARD1_3
-								await socket.ConnectAsync(ipAddress, port).ConfigureAwait(false);
+							socket.ConnectAsync(ipAddress, port)
 #else
-								await Task.Factory.FromAsync(socket.BeginConnect, socket.EndConnect, hostname, port, null).ConfigureAwait(false);
+							Task.Factory.FromAsync(socket.BeginConnect, socket.EndConnect, hostname, port, null)
 #endif
-							}
-							catch (ObjectDisposedException ex) when (cancellationToken.IsCancellationRequested)
-							{
-								throw new MySqlException("Connect Timeout expired.", ex);
-							}
+						};
+						if (connectTimeout != null)
+						{
+							connectTasks.Add(Task.Delay((int)(connectTimeout.Value - DateTime.UtcNow).TotalMilliseconds));
 						}
+						await Task.WhenAny(connectTasks).ConfigureAwait(false);
+						if (socket.Connected)
+						{
+							m_socket = socket;
+							m_transmitter = new PacketTransmitter(m_socket);
+							m_state = State.Connected;
+							return true;
+						}
+						if (connectTimeout != null && DateTime.UtcNow > connectTimeout.Value)
+						{
+							socket.Dispose();
+							throw new MySqlException("Connect Timeout expired.");
+						}
+						// some other error occurred, continue on to next hostname
+						socket.Dispose();
+
 					}
 					catch (SocketException)
 					{
-						Utility.Dispose(ref socket);
-						continue;
+						socket.Dispose();
 					}
-
-					m_socket = socket;
-					m_transmitter = new PacketTransmitter(m_socket);
-					m_state = State.Connected;
-					return true;
 				}
 			}
-
 			return false;
 		}
 

--- a/src/MySqlConnector/Serialization/MySqlSession.cs
+++ b/src/MySqlConnector/Serialization/MySqlSession.cs
@@ -1,7 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Net;
 using System.Net.Sockets;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using MySql.Data.MySqlClient;
@@ -49,7 +51,100 @@ namespace MySql.Data.Serialization
 			m_state = State.Closed;
 		}
 
-		public async Task<bool> ConnectAsync(IEnumerable<string> hostnames, int port)
+		public async Task ConnectAsync(IEnumerable<string> hosts, int port, string userId, string password, string database, CancellationToken cancellationToken)
+		{
+			var connected = await OpenSocketAsync(hosts, port).ConfigureAwait(false);
+			if (!connected)
+				throw new MySqlException("Unable to connect to any of the specified MySQL hosts.");
+
+			var payload = await ReceiveAsync(cancellationToken).ConfigureAwait(false);
+			var reader = new ByteArrayReader(payload.ArraySegment.Array, payload.ArraySegment.Offset, payload.ArraySegment.Count);
+			var initialHandshake = new InitialHandshakePacket(reader);
+			if (initialHandshake.AuthPluginName != "mysql_native_password")
+				throw new NotSupportedException("Only 'mysql_native_password' authentication method is supported.");
+			ServerVersion = new ServerVersion(Encoding.ASCII.GetString(initialHandshake.ServerVersion));
+			AuthPluginData = initialHandshake.AuthPluginData;
+
+			var response = HandshakeResponse41Packet.Create(initialHandshake, userId, password, database);
+			payload = new PayloadData(new ArraySegment<byte>(response));
+			await SendReplyAsync(payload, cancellationToken).ConfigureAwait(false);
+			await ReceiveReplyAsync(cancellationToken).ConfigureAwait(false);
+		}
+
+		public async Task ResetConnectionAsync(string userId, string password, string database, CancellationToken cancellationToken)
+		{
+			if (ServerVersion.Version.CompareTo(ServerVersions.SupportsResetConnection) >= 0)
+			{
+				await SendAsync(ResetConnectionPayload.Create(), cancellationToken).ConfigureAwait(false);
+				var payload = await ReceiveReplyAsync(cancellationToken).ConfigureAwait(false);
+				OkPayload.Create(payload);
+			}
+			else
+			{
+				// optimistically hash the password with the challenge from the initial handshake (supported by MariaDB; doesn't appear to be supported by MySQL)
+				var hashedPassword = AuthenticationUtility.HashPassword(AuthPluginData, 0, password);
+				var payload = ChangeUserPayload.Create(userId, hashedPassword, database);
+				await SendAsync(payload, cancellationToken).ConfigureAwait(false);
+				payload = await ReceiveReplyAsync(cancellationToken).ConfigureAwait(false);
+				if (payload.HeaderByte == AuthenticationMethodSwitchRequestPayload.Signature)
+				{
+					// if the server didn't support the hashed password; rehash with the new challenge
+					var switchRequest = AuthenticationMethodSwitchRequestPayload.Create(payload);
+					if (switchRequest.Name != "mysql_native_password")
+						throw new NotSupportedException("Only 'mysql_native_password' authentication method is supported.");
+					hashedPassword = AuthenticationUtility.HashPassword(switchRequest.Data, 0, password);
+					payload = new PayloadData(new ArraySegment<byte>(hashedPassword));
+					await SendReplyAsync(payload, cancellationToken).ConfigureAwait(false);
+					payload = await ReceiveReplyAsync(cancellationToken).ConfigureAwait(false);
+				}
+				OkPayload.Create(payload);
+			}
+		}
+
+		public async Task<bool> TryPingAsync(CancellationToken cancellationToken)
+		{
+			await SendAsync(PingPayload.Create(), cancellationToken).ConfigureAwait(false);
+			try
+			{
+				var payload = await ReceiveReplyAsync(cancellationToken).ConfigureAwait(false);
+				OkPayload.Create(payload);
+				return true;
+			}
+			catch (EndOfStreamException)
+			{
+			}
+			catch (SocketException)
+			{
+			}
+
+			return false;
+		}
+
+		// Starts a new conversation with the server by sending the first packet.
+		public Task SendAsync(PayloadData payload, CancellationToken cancellationToken)
+			=> TryAsync(m_transmitter.SendAsync, payload, cancellationToken);
+
+		// Starts a new conversation with the server by receiving the first packet.
+		public ValueTask<PayloadData> ReceiveAsync(CancellationToken cancellationToken)
+			=> TryAsync(m_transmitter.ReceiveAsync, cancellationToken);
+
+		// Continues a conversation with the server by receiving a response to a packet sent with 'Send' or 'SendReply'.
+		public ValueTask<PayloadData> ReceiveReplyAsync(CancellationToken cancellationToken)
+			=> TryAsync(m_transmitter.ReceiveReplyAsync, cancellationToken);
+
+		// Continues a conversation with the server by sending a reply to a packet received with 'Receive' or 'ReceiveReply'.
+		public Task SendReplyAsync(PayloadData payload, CancellationToken cancellationToken)
+			=> TryAsync(m_transmitter.SendReplyAsync, payload, cancellationToken);
+
+		private void VerifyConnected()
+		{
+			if (m_state == State.Closed)
+				throw new ObjectDisposedException(nameof(MySqlSession));
+			if (m_state != State.Connected)
+				throw new InvalidOperationException("MySqlSession is not connected.");
+		}
+
+		private async Task<bool> OpenSocketAsync(IEnumerable<string> hostnames, int port)
 		{
 			foreach (var hostname in hostnames)
 			{
@@ -93,30 +188,6 @@ namespace MySql.Data.Serialization
 			return false;
 		}
 
-		// Starts a new conversation with the server by sending the first packet.
-		public Task SendAsync(PayloadData payload, CancellationToken cancellationToken)
-			=> TryAsync(m_transmitter.SendAsync, payload, cancellationToken);
-
-		// Starts a new conversation with the server by receiving the first packet.
-		public ValueTask<PayloadData> ReceiveAsync(CancellationToken cancellationToken)
-			=> TryAsync(m_transmitter.ReceiveAsync, cancellationToken);
-
-		// Continues a conversation with the server by receiving a response to a packet sent with 'Send' or 'SendReply'.
-		public ValueTask<PayloadData> ReceiveReplyAsync(CancellationToken cancellationToken)
-			=> TryAsync(m_transmitter.ReceiveReplyAsync, cancellationToken);
-
-		// Continues a conversation with the server by sending a reply to a packet received with 'Receive' or 'ReceiveReply'.
-		public Task SendReplyAsync(PayloadData payload, CancellationToken cancellationToken)
-			=> TryAsync(m_transmitter.SendReplyAsync, payload, cancellationToken);
-
-
-		private void VerifyConnected()
-		{
-			if (m_state == State.Closed)
-				throw new ObjectDisposedException(nameof(MySqlSession));
-			if (m_state != State.Connected)
-				throw new InvalidOperationException("MySqlSession is not connected.");
-		}
 
 		private Task TryAsync<TArg>(Func<TArg, CancellationToken, Task> func, TArg arg, CancellationToken cancellationToken)
 		{

--- a/src/MySqlConnector/Serialization/MySqlSession.cs
+++ b/src/MySqlConnector/Serialization/MySqlSession.cs
@@ -44,9 +44,16 @@ namespace MySql.Data.Serialization
 			}
 			if (m_socket != null)
 			{
-				if (m_socket.Connected)
-					m_socket.Shutdown(SocketShutdown.Both);
-				Utility.Dispose(ref m_socket);
+				try
+				{
+					if (m_socket.Connected)
+						m_socket.Shutdown(SocketShutdown.Both);
+					m_socket.Dispose();
+				}
+				catch (SocketException)
+				{
+				}
+				m_socket = null;
 			}
 			m_state = State.Closed;
 		}

--- a/src/MySqlConnector/Serialization/MySqlSession.cs
+++ b/src/MySqlConnector/Serialization/MySqlSession.cs
@@ -10,7 +10,7 @@ using MySql.Data.MySqlClient;
 
 namespace MySql.Data.Serialization
 {
-	internal sealed class MySqlSession : IDisposable
+	internal sealed class MySqlSession
 	{
 		public MySqlSession(ConnectionPool pool)
 		{
@@ -20,12 +20,7 @@ namespace MySql.Data.Serialization
 		public ServerVersion ServerVersion { get; set; }
 		public byte[] AuthPluginData { get; set; }
 		public ConnectionPool Pool { get; }
-		public bool ReturnToPool() => Pool != null && Pool.Return(this);
-
-		public void Dispose()
-		{
-			DisposeAsync(CancellationToken.None).GetAwaiter().GetResult();
-		}
+		public void ReturnToPool() => Pool.Return(this);
 
 		public async Task DisposeAsync(CancellationToken cancellationToken)
 		{

--- a/src/MySqlConnector/project.json
+++ b/src/MySqlConnector/project.json
@@ -32,7 +32,7 @@
 			"frameworkAssemblies": {
 			},
 			"dependencies": {
-				"System.Collections": "4.0.11-*",
+				"System.Collections.Concurrent": "4.0.12-*",
 				"System.Data.Common": "4.1.0-*",
 				"System.Globalization": "4.0.11-*",
 				"System.IO": "4.1.0-*",

--- a/tests/MySqlConnector.Tests/MySqlConnectionStringBuilderTests.cs
+++ b/tests/MySqlConnector.Tests/MySqlConnectionStringBuilderTests.cs
@@ -17,6 +17,7 @@ namespace MySql.Data.Tests
 #else
 			Assert.Equal(true, csb.ConnectionReset);
 #endif
+			Assert.Equal(15u, csb.ConnectionTimeout);
 #if BASELINE
 			Assert.False(csb.UseAffectedRows);
 #else
@@ -39,10 +40,11 @@ namespace MySql.Data.Tests
 		[Fact]
 		public void ParseConnectionString()
 		{
-			var csb = new MySqlConnectionStringBuilder { ConnectionString = "Data Source=db-server;Port=1234;Uid=username;pwd=Pass1234;Initial Catalog=schema_name;Allow User Variables=true;Character Set=latin1;Convert Zero Datetime=true;Pooling=no;OldGuids=true;Compress=true;ConnectionReset=false;minpoolsize=5;maxpoolsize=15;persistsecurityinfo=yes;useaffectedrows=false" };
+			var csb = new MySqlConnectionStringBuilder { ConnectionString = "Data Source=db-server;Port=1234;Uid=username;pwd=Pass1234;Initial Catalog=schema_name;Allow User Variables=true;Character Set=latin1;Convert Zero Datetime=true;Pooling=no;OldGuids=true;Compress=true;ConnectionReset=false;minpoolsize=5;maxpoolsize=15;persistsecurityinfo=yes;useaffectedrows=false;connect timeout=30" };
 			Assert.Equal(true, csb.AllowUserVariables);
 			Assert.Equal("latin1", csb.CharacterSet);
 			Assert.Equal(false, csb.ConnectionReset);
+			Assert.Equal(30u, csb.ConnectionTimeout);
 			Assert.Equal(true, csb.ConvertZeroDateTime);
 			Assert.Equal("schema_name", csb.Database);
 			Assert.Equal(15u, csb.MaximumPoolSize);

--- a/tests/SideBySide.New/ConnectAsync.cs
+++ b/tests/SideBySide.New/ConnectAsync.cs
@@ -75,7 +75,7 @@ namespace SideBySide
 		{
 			var csb = new MySqlConnectionStringBuilder
 			{
-				Server = "www.mysql.com,invalid.example.net,localhost",
+				Server = "invalid.example.net,localhost",
 				Port = 3306,
 				UserID = Constants.UserName,
 				Password = Constants.Password,

--- a/tests/SideBySide.New/ConnectSync.cs
+++ b/tests/SideBySide.New/ConnectSync.cs
@@ -104,7 +104,7 @@ namespace SideBySide
 		{
 			var csb = new MySqlConnectionStringBuilder
 			{
-				Server = "www.mysql.com,invalid.example.net,localhost",
+				Server = "invalid.example.net,localhost",
 				Port = 3306,
 				UserID = Constants.UserName,
 				Password = Constants.Password,

--- a/tests/SideBySide.New/ConnectSync.cs
+++ b/tests/SideBySide.New/ConnectSync.cs
@@ -1,4 +1,12 @@
-﻿using System.Data;
+﻿using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Diagnostics;
+using System.Net;
+using System.Net.Sockets;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
 using MySql.Data.MySqlClient;
 using Xunit;
 
@@ -122,6 +130,25 @@ namespace SideBySide
 				Assert.Equal(ConnectionState.Closed, connection.State);
 				connection.Open();
 				Assert.Equal(ConnectionState.Open, connection.State);
+			}
+		}
+
+		[Fact(Skip = "Not yet implemented")]
+		public void ConnectTimeout()
+		{
+			var csb = new MySqlConnectionStringBuilder
+			{
+				Server = "www.mysql.com",
+				Pooling = false,
+				ConnectionTimeout = 3,
+			};
+
+			using (var connection = new MySqlConnection(csb.ConnectionString))
+			{
+				var stopwatch = Stopwatch.StartNew();
+				Assert.Throws<MySqlException>(() => connection.Open());
+				stopwatch.Stop();
+				Assert.InRange(stopwatch.ElapsedMilliseconds, 2800, 3500);
 			}
 		}
 

--- a/tests/SideBySide.New/ConnectSync.cs
+++ b/tests/SideBySide.New/ConnectSync.cs
@@ -133,7 +133,7 @@ namespace SideBySide
 			}
 		}
 
-		[Fact(Skip = "Not yet implemented")]
+		[Fact]
 		public void ConnectTimeout()
 		{
 			var csb = new MySqlConnectionStringBuilder

--- a/tests/SideBySide.New/ConnectionPool.cs
+++ b/tests/SideBySide.New/ConnectionPool.cs
@@ -79,7 +79,7 @@ namespace SideBySide
 			}
 		}
 
-		[Fact(Skip = "Not yet implemented")]
+		[Fact]
 		public async Task ExhaustConnectionPoolWithTimeout()
 		{
 			var csb = Constants.CreateConnectionStringBuilder();
@@ -109,7 +109,7 @@ namespace SideBySide
 				connection.Dispose();
 		}
 
-		[Fact(Skip = "Not yet implemented")]
+		[Fact]
 		public async Task ExhaustConnectionPoolBeforeTimeout()
 		{
 			var csb = Constants.CreateConnectionStringBuilder();

--- a/tests/SideBySide.New/ConnectionPool.cs
+++ b/tests/SideBySide.New/ConnectionPool.cs
@@ -9,7 +9,7 @@ using Xunit;
 
 namespace SideBySide
 {
-	public class ConnectionPool : IDisposable
+	public class ConnectionPool
 	{
 		[Theory]
 		[InlineData(false, 11, 0L)]
@@ -80,37 +80,7 @@ namespace SideBySide
 		}
 
 		[Fact]
-		public async Task ExhaustConnectionPoolWithTimeout()
-		{
-			var csb = Constants.CreateConnectionStringBuilder();
-			csb.Pooling = true;
-			csb.MinimumPoolSize = 0;
-			csb.MaximumPoolSize = 3;
-			csb.ConnectionTimeout = 5;
-
-			var connections = new List<MySqlConnection>();
-
-			for (int i = 0; i < csb.MaximumPoolSize; i++)
-			{
-				var connection = new MySqlConnection(csb.ConnectionString);
-				await connection.OpenAsync().ConfigureAwait(false);
-				connections.Add(connection);
-			}
-
-			using (var extraConnection = new MySqlConnection(csb.ConnectionString))
-			{
-				var stopwatch = Stopwatch.StartNew();
-				Assert.Throws<MySqlException>(() => extraConnection.Open());
-				stopwatch.Stop();
-				Assert.InRange(stopwatch.ElapsedMilliseconds, 4500, 5500);
-			}
-
-			foreach (var connection in connections)
-				connection.Dispose();
-		}
-
-		[Fact]
-		public async Task ExhaustConnectionPoolBeforeTimeout()
+		public async Task ExhaustConnectionPool()
 		{
 			var csb = Constants.CreateConnectionStringBuilder();
 			csb.Pooling = true;
@@ -148,9 +118,5 @@ namespace SideBySide
 				connection.Dispose();
 		}
 
-		public void Dispose()
-		{
-			MySqlConnection.ClearAllPools();
-		}
 	}
 }

--- a/tests/SideBySide.New/DatabaseFixture.cs
+++ b/tests/SideBySide.New/DatabaseFixture.cs
@@ -22,7 +22,6 @@ namespace SideBySide
 			if (disposing)
 			{
 				Connection.Dispose();
-				MySqlConnection.ClearAllPools();
 			}
 		}
 	}


### PR DESCRIPTION
I've taken a stab at fixing the connection pool.  I tested this implementation with MySqlConnector.Performance, but it seems to hang the SideBySide.New tests.  SideBySide.New does not print which test is currently running, so I'm not sure how to debug.

@bgrainger can you take a look at the SideBySide.New tests and see if you can tell why they are hanging?  If you can add logging to it to print the method it's in, I can resolve the bug.  I tried briefly but I'm not very familiar with XUnit.

Async targets are running stable at 1500 Requests Per Second in the Performance Tests.  Very nice!!!  I'm running on an Intel Core i5-6260U, load test, web app, and database all running on the same machine.  Should do better on a dedicated app server.

	Rate = 1500 RPS
	Duration = 10s
	Targets = targets-async.txt

	Requests      [total, rate]            15000, 1500.10
	Duration      [total, attack, wait]    10.000748548s, 9.999322811s, 1.425737ms
	Latencies     [mean, 50, 95, 99, max]  23.299198ms, 2.395148ms, 168.782969ms, 271.810346ms, 395.213902ms
	Bytes In      [total, mean]            173108268, 11540.55
	Bytes Out     [total, mean]            5561250, 370.75
	Success       [ratio]                  100.00%
	Status Codes  [code:count]             200:15000  

