### PR TITLE
travis ci: use docker image for MySql 5.7

### DIFF
--- a/.travis.install-mysql-5.7.sh
+++ b/.travis.install-mysql-5.7.sh
@@ -1,6 +1,0 @@
-echo mysql-apt-config mysql-apt-config/select-server select mysql-5.7 | sudo debconf-set-selections
-wget http://dev.mysql.com/get/mysql-apt-config_0.7.3-1_all.deb
-sudo dpkg --install mysql-apt-config_0.7.3-1_all.deb
-sudo apt-get update -q
-sudo apt-get install -q -y -o Dpkg::Options::=--force-confnew mysql-server
-sudo mysql_upgrade

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,22 +1,15 @@
 sudo: required
 dist: trusty
-addons:
-  apt:
-    packages:
-    - mysql-server-5.6
-    - mysql-client-core-5.6
-    - mysql-client-5.6
-services: mysql
+services: docker
 
 before_install:
-  - bash .travis.install-mysql-5.7.sh
-  - |-
-    mysql -u root -e "CREATE USER mysqltest IDENTIFIED BY 'test;key=\"val'; GRANT ALL ON *.* TO mysqltest;"
-    mysql -u root -e "CREATE USER no_password;"
+  - docker pull mysql:5.7
+  - docker run --name mysql -e MYSQL_ROOT_PASSWORD='test' -p 3306:3306 -d mysql:5.7
   - sudo sh -c 'echo "deb [arch=amd64] https://apt-mo.trafficmanager.net/repos/dotnet-release/ trusty main" > /etc/apt/sources.list.d/dotnetdev.list'
   - sudo apt-key adv --keyserver apt-mo.trafficmanager.net --recv-keys 417A0893
   - sudo apt-get update
   - sudo apt-get install -y dotnet-dev-1.0.0-preview2-003121
+  - docker exec -it mysql mysql -uroot -ptest -e "CREATE USER 'mysqltest'@'%' IDENTIFIED BY 'test;key=\"val'; GRANT ALL ON *.* TO mysqltest; CREATE USER 'no_password'@'172.17.0.1';"
 
 script:
   - dotnet restore


### PR DESCRIPTION
Travis CI seems to fail randomly.  I think it may be a problem with the MySQL 5.7 service not starting.

This PR switches Travis CI to use a Docker image for MySQL 5.7, which may be more reliable for us.