### PR TITLE
Send binary payloads as raw bytes

### DIFF
--- a/src/MySqlConnector/MySqlClient/MySqlCommand.cs
+++ b/src/MySqlConnector/MySqlClient/MySqlCommand.cs
@@ -149,8 +149,7 @@ namespace MySql.Data.MySqlClient
 				if (connection.OldGuids)
 					statementPreparerOptions |= StatementPreparerOptions.OldGuids;
 				var preparer = new MySqlStatementPreparer(CommandText, m_parameterCollection, statementPreparerOptions);
-				preparer.BindParameters();
-				var payload = new PayloadData(new ArraySegment<byte>(Payload.CreateEofStringPayload(CommandKind.Query, preparer.PreparedSql)));
+				var payload = new PayloadData(preparer.ParseAndBindParameters());
 				await Session.SendAsync(payload, cancellationToken).ConfigureAwait(false);
 				reader = await MySqlDataReader.CreateAsync(this, behavior, cancellationToken).ConfigureAwait(false);
 				return reader;

--- a/src/MySqlConnector/Utility.cs
+++ b/src/MySqlConnector/Utility.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Globalization;
+using System.IO;
 using System.Text;
 
 namespace MySql.Data
@@ -23,5 +24,41 @@ namespace MySql.Data
 
 		public static string GetString(this Encoding encoding, ArraySegment<byte> arraySegment)
 			=> encoding.GetString(arraySegment.Array, arraySegment.Offset, arraySegment.Count);
+
+		public static void WriteUtf8(this BinaryWriter writer, string value) =>
+			WriteUtf8(writer, value, 0, value.Length);
+
+		public static void WriteUtf8(this BinaryWriter writer, string value, int startIndex, int length)
+		{
+			var endIndex = startIndex + length;
+			while (startIndex < endIndex)
+			{
+				int codePoint = char.ConvertToUtf32(value, startIndex);
+				startIndex++;
+				if (codePoint < 0x80)
+				{
+					writer.Write((byte) codePoint);
+				}
+				else if (codePoint < 0x800)
+				{
+					writer.Write((byte) (0xC0 | ((codePoint >> 6) & 0x1F)));
+					writer.Write((byte) (0x80 | (codePoint & 0x3F)));
+				}
+				else if (codePoint < 0x10000)
+				{
+					writer.Write((byte) (0xE0 | ((codePoint >> 12) & 0x0F)));
+					writer.Write((byte) (0x80 | ((codePoint >> 6) & 0x3F)));
+					writer.Write((byte) (0x80 | (codePoint & 0x3F)));
+				}
+				else
+				{
+					writer.Write((byte) (0xF0 | ((codePoint >> 18) & 0x07)));
+					writer.Write((byte) (0x80 | ((codePoint >> 12) & 0x3F)));
+					writer.Write((byte) (0x80 | ((codePoint >> 6) & 0x3F)));
+					writer.Write((byte) (0x80 | (codePoint & 0x3F)));
+					startIndex++;
+				}
+			}
+		}
 	}
 }

--- a/tests/MySqlConnector.Tests/Utf8Tests.cs
+++ b/tests/MySqlConnector.Tests/Utf8Tests.cs
@@ -1,0 +1,29 @@
+﻿using System.IO;
+using Xunit;
+
+namespace MySql.Data.Tests
+{
+    public class Utf8Tests
+    {
+	    [Theory]
+	    [InlineData("a", new byte[] { 0x61 })]
+	    [InlineData("\u007F", new byte[] { 0x7F })]
+		[InlineData("\u0080", new byte[] { 0xC2, 0x80 })]
+	    [InlineData("Ā", new byte[] { 0xC4, 0x80 })]
+		[InlineData("\u07FF", new byte[] { 0xDF, 0xBF })]
+		[InlineData("\u0800", new byte[] { 0xE0, 0xA0, 0x80 })]
+		[InlineData("\uFFFF", new byte[] { 0xEF, 0xBF, 0xBF })]
+		[InlineData("\uFFFF", new byte[] { 0xEF, 0xBF, 0xBF })]
+		[InlineData("\U00010000", new byte[] { 0xF0, 0x90, 0x80, 0x80 })]
+		[InlineData("\U0010FFF0\U0010FFF1", new byte[] { 0xF4, 0x8F, 0xBF, 0xB0, 0xF4, 0x8F, 0xBF, 0xB1 })]
+	    public void Encode(string input, byte[] expected)
+	    {
+			using (var stream = new MemoryStream())
+			using (var writer = new BinaryWriter(stream))
+			{
+				writer.WriteUtf8(input);
+				Assert.Equal(expected, stream.ToArray());
+			}
+	    }
+    }
+}


### PR DESCRIPTION
This sends byte arrays as the raw bytes on the wire instead of hex-encoded; this doubles the size of a BLOB that can be sent to a MySQL server for a given `max_allowed_packet` size.