### PR TITLE
refactor ConnectionPool.Return. fixes #58

### DIFF
--- a/src/MySqlConnector/Serialization/MySqlSession.cs
+++ b/src/MySqlConnector/Serialization/MySqlSession.cs
@@ -12,14 +12,16 @@ namespace MySql.Data.Serialization
 {
 	internal sealed class MySqlSession
 	{
-		public MySqlSession(ConnectionPool pool)
+		public MySqlSession(ConnectionPool pool, int poolGeneration=0)
 		{
 			Pool = pool;
+			PoolGeneration = poolGeneration;
 		}
 
 		public ServerVersion ServerVersion { get; set; }
 		public byte[] AuthPluginData { get; set; }
 		public ConnectionPool Pool { get; }
+		public int PoolGeneration { get; }
 
 		public void ReturnToPool() => Pool?.Return(this);
 


### PR DESCRIPTION
Connection pool has a "generation" integer, set at 0 initially and incremented by 1 every time the pool is cleared

When connections are leased out of the pool, the generation is passed to `MySqlSession`.   When they are returned to the pool, the current generation of the pool is compared to the generation of the session that is being returned.  If there is a mismatch, the session is disposed instead of being returned to the pool

`ConnectionPool.ClearAsync` tries to dequeue all available sessions in the queue, and dispose of them if there is a generation mismatch.  Since `ConnectionPool.GetSessionAsync` can also dequeue a session during this process, it too checks for a generation mismatch and disposes the session if it finds one.  This allows the entire process to remain lock-free.