### PR TITLE
Add ServerThread and fix baseline ClearConnectionPool test

### DIFF
--- a/src/MySqlConnector/MySqlClient/MySqlConnection.cs
+++ b/src/MySqlConnector/MySqlClient/MySqlConnection.cs
@@ -225,7 +225,7 @@ namespace MySql.Data.MySqlClient
 					}
 					else
 					{
-						var session = new MySqlSession(null);
+						var session = new MySqlSession();
 						await session.ConnectAsync(m_connectionStringBuilder.Server.Split(','), (int) m_connectionStringBuilder.Port, m_connectionStringBuilder.UserID,
 							m_connectionStringBuilder.Password, m_connectionStringBuilder.Database, ioBehavior, linkedSource.Token).ConfigureAwait(false);
 						return session;

--- a/src/MySqlConnector/MySqlClient/MySqlConnection.cs
+++ b/src/MySqlConnector/MySqlClient/MySqlConnection.cs
@@ -150,6 +150,8 @@ namespace MySql.Data.MySqlClient
 
 		public override string ServerVersion => m_session.ServerVersion.OriginalString;
 
+		public int ServerThread => m_session.ConnectionId;
+
 		public static void ClearPool(MySqlConnection connection) => ClearPoolAsync(connection, IOBehavior.Synchronous, CancellationToken.None).GetAwaiter().GetResult();
 		public static Task ClearPoolAsync(MySqlConnection connection) => ClearPoolAsync(connection, IOBehavior.Asynchronous, CancellationToken.None);
 		public static Task ClearPoolAsync(MySqlConnection connection, CancellationToken cancellationToken) => ClearPoolAsync(connection, IOBehavior.Asynchronous, cancellationToken);

--- a/src/MySqlConnector/Serialization/InitialHandshakePacket.cs
+++ b/src/MySqlConnector/Serialization/InitialHandshakePacket.cs
@@ -7,15 +7,16 @@ namespace MySql.Data.Serialization
 	{
 		public ProtocolCapabilities ProtocolCapabilities { get; }
 
+		public byte[] ServerVersion { get; }
+		public int ConnectionId { get; }
 		public byte[] AuthPluginData { get; }
 		public string AuthPluginName { get; }
-		public byte[] ServerVersion { get; }
 
 		internal InitialHandshakePacket(ByteArrayReader reader)
 		{
 			reader.ReadByte(c_protocolVersion);
 			ServerVersion = reader.ReadNullTerminatedByteString();
-			var connectionId = reader.ReadInt32();
+			ConnectionId = reader.ReadInt32();
 			AuthPluginData = reader.ReadByteString(8);
 			reader.ReadByte(0);
 			var capabilityFlagsLow = reader.ReadUInt16();

--- a/src/MySqlConnector/Serialization/MySqlSession.cs
+++ b/src/MySqlConnector/Serialization/MySqlSession.cs
@@ -12,7 +12,12 @@ namespace MySql.Data.Serialization
 {
 	internal sealed class MySqlSession
 	{
-		public MySqlSession(ConnectionPool pool, int poolGeneration=0)
+		public MySqlSession()
+			: this(null, 0)
+		{
+		}
+
+		public MySqlSession(ConnectionPool pool, int poolGeneration)
 		{
 			Pool = pool;
 			PoolGeneration = poolGeneration;

--- a/src/MySqlConnector/Serialization/MySqlSession.cs
+++ b/src/MySqlConnector/Serialization/MySqlSession.cs
@@ -24,6 +24,7 @@ namespace MySql.Data.Serialization
 		}
 
 		public ServerVersion ServerVersion { get; set; }
+		public int ConnectionId { get; set; }
 		public byte[] AuthPluginData { get; set; }
 		public ConnectionPool Pool { get; }
 		public int PoolGeneration { get; }
@@ -73,6 +74,7 @@ namespace MySql.Data.Serialization
 			if (initialHandshake.AuthPluginName != "mysql_native_password")
 				throw new NotSupportedException("Only 'mysql_native_password' authentication method is supported.");
 			ServerVersion = new ServerVersion(Encoding.ASCII.GetString(initialHandshake.ServerVersion));
+			ConnectionId = initialHandshake.ConnectionId;
 			AuthPluginData = initialHandshake.AuthPluginData;
 
 			var response = HandshakeResponse41Packet.Create(initialHandshake, userId, password, database);


### PR DESCRIPTION
Exposes `MySqlConnection.ServerThread` so that the `ClearConnectionPool` test can be rewritten to work with both MySqlConnector and MySql.Data.