### PR TITLE
Skip tests based on server capabilities

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ before_install:
   - sudo apt-key adv --keyserver apt-mo.trafficmanager.net --recv-keys 417A0893
   - sudo apt-get update
   - sudo apt-get install -y dotnet-dev-1.0.0-preview2-003121
-  - docker exec -it mysql mysql -uroot -ptest -e "CREATE USER 'mysqltest'@'%' IDENTIFIED BY 'test;key=\"val'; GRANT ALL ON *.* TO mysqltest; CREATE USER 'no_password'@'172.17.0.1';"
+  - docker exec -it mysql mysql -uroot -ptest -e "CREATE USER 'mysqltest'@'%' IDENTIFIED BY 'test;key=\"val'; GRANT ALL ON *.* TO mysqltest; CREATE USER 'no_password'@'172.17.0.1'; SET GLOBAL max_allowed_packet=104857600;"
 
 script:
   - dotnet restore

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,8 +12,8 @@ build_script:
     dotnet build tests\SideBySide.New --configuration Release
 before_test:
 - cmd: |-
-    "C:\Program Files\MySQL\MySQL Server 5.7\bin\mysql.exe" -u root --password=Password12! -e "CREATE USER mysqltest IDENTIFIED BY 'test;key=\"val'; GRANT ALL ON *.* TO mysqltest;"
-    "C:\Program Files\MySQL\MySQL Server 5.7\bin\mysql.exe" -u root --password=Password12! -e "CREATE USER no_password;"
+    "C:\Program Files\MySQL\MySQL Server 5.7\bin\mysql.exe" -u root --password=Password12! -e "CREATE USER mysqltest IDENTIFIED BY 'test;key=\"val'; GRANT ALL ON *.* TO mysqltest; CREATE USER no_password;"
+    "C:\Program Files\MySQL\MySQL Server 5.7\bin\mysql.exe" -u root --password=Password12! -e "SET GLOBAL max_allowed_packet=104857600;"
 test_script:
 - cmd: |-
     dotnet test tests\MySqlConnector.Tests --configuration Release

--- a/tests/SideBySide.Baseline/SideBySide.Baseline.csproj
+++ b/tests/SideBySide.Baseline/SideBySide.Baseline.csproj
@@ -35,8 +35,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Dapper, Version=1.40.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Dapper.1.42\lib\net45\Dapper.dll</HintPath>
+    <Reference Include="Dapper, Version=1.50.2.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Dapper.1.50.2\lib\net451\Dapper.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="MySql.Data, Version=6.9.8.0, Culture=neutral, PublicKeyToken=c5687fc88969c44d, processorArchitecture=MSIL">

--- a/tests/SideBySide.Baseline/SideBySide.Baseline.csproj
+++ b/tests/SideBySide.Baseline/SideBySide.Baseline.csproj
@@ -105,6 +105,9 @@
     <Compile Include="..\SideBySide.New\QueryTests.cs">
       <Link>QueryTests.cs</Link>
     </Compile>
+    <Compile Include="..\SideBySide.New\TestUtilities.cs">
+      <Link>TestUtilities.cs</Link>
+    </Compile>
     <Compile Include="..\SideBySide.New\Transaction.cs">
       <Link>Transaction.cs</Link>
     </Compile>

--- a/tests/SideBySide.Baseline/packages.config
+++ b/tests/SideBySide.Baseline/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Dapper" version="1.42" targetFramework="net46" />
+  <package id="Dapper" version="1.50.2" targetFramework="net46" />
   <package id="MySql.Data" version="6.9.8" targetFramework="net46" />
   <package id="xunit" version="2.1.0" targetFramework="net46" />
   <package id="xunit.abstractions" version="2.0.0" targetFramework="net46" />

--- a/tests/SideBySide.New/DataTypes.cs
+++ b/tests/SideBySide.New/DataTypes.cs
@@ -486,11 +486,8 @@ namespace SideBySide
 				lastInsertId = cmd.LastInsertedId;
 			}
 
-			foreach (var queryResult in await m_database.Connection.QueryAsync<byte[]>(Invariant($"select `{column}` from datatypes.blobs where rowid = {lastInsertId}")).ConfigureAwait(false))
-			{
-				Assert.Equal(data, queryResult);
-				break;
-			}
+			var queryResult = (await m_database.Connection.QueryAsync<byte[]>(Invariant($"select `{column}` from datatypes.blobs where rowid = {lastInsertId}")).ConfigureAwait(false)).Single();
+			TestUtilities.AssertEqual(data, queryResult);
 
 			await m_database.Connection.ExecuteAsync(Invariant($"delete from datatypes.blobs where rowid = {lastInsertId}")).ConfigureAwait(false);
 		}
@@ -519,11 +516,8 @@ namespace SideBySide
 				lastInsertId = cmd.LastInsertedId;
 			}
 
-			foreach (var queryResult in m_database.Connection.Query<byte[]>(Invariant($"select `{column}` from datatypes.blobs where rowid = {lastInsertId}")))
-			{
-				Assert.Equal(data, queryResult);
-				break;
-			}
+			var queryResult = m_database.Connection.Query<byte[]>(Invariant($"select `{column}` from datatypes.blobs where rowid = {lastInsertId}")).Single();
+			TestUtilities.AssertEqual(data, queryResult);
 
 			m_database.Connection.Execute(Invariant($"delete from datatypes.blobs where rowid = {lastInsertId}"));
 		}

--- a/tests/SideBySide.New/DataTypes.cs
+++ b/tests/SideBySide.New/DataTypes.cs
@@ -545,20 +545,26 @@ namespace SideBySide
 		[InlineData("Value", new[] { null, "NULL", "BOOLEAN", "ARRAY", "ARRAY", "ARRAY", "INTEGER", "INTEGER", "OBJECT", "OBJECT" })]
 		public void JsonType(string column, string[] expectedTypes)
 		{
-			var types = m_database.Connection.Query<string>(@"select JSON_TYPE(value) from datatypes.json_core order by rowid;").ToList();
-			Assert.Equal(expectedTypes, types);
+			if (TestUtilities.SupportsJson(m_database.Connection.ServerVersion))
+			{
+				var types = m_database.Connection.Query<string>(@"select JSON_TYPE(value) from datatypes.json_core order by rowid;").ToList();
+				Assert.Equal(expectedTypes, types);
+			}
 		}
 
 		[Theory]
 		[InlineData("value", new[] { null, "null", "true", "[]", "[0]", "[1]", "0", "1", "{}", "{\"a\": \"b\"}" })]
 		public void QueryJson(string column, string[] expected)
 		{
-			string dataTypeName = "JSON";
+			if (TestUtilities.SupportsJson(m_database.Connection.ServerVersion))
+			{
+				string dataTypeName = "JSON";
 #if BASELINE
-			// mysql-connector-net returns "VARCHAR" for "JSON"
-			dataTypeName = "VARCHAR";
+				// mysql-connector-net returns "VARCHAR" for "JSON"
+				dataTypeName = "VARCHAR";
 #endif
-			DoQuery("json_core", column, dataTypeName, expected, reader => reader.GetString(0), omitWhereTest: true);
+				DoQuery("json_core", column, dataTypeName, expected, reader => reader.GetString(0), omitWhereTest: true);
+			}
 		}
 
 		private static byte[] GetBytes(DbDataReader reader)

--- a/tests/SideBySide.New/DataTypes.cs
+++ b/tests/SideBySide.New/DataTypes.cs
@@ -465,8 +465,15 @@ namespace SideBySide
 		[Theory]
 		[InlineData("TinyBlob", 255)]
 		[InlineData("Blob", 65535)]
+		[InlineData("MediumBlob", 16777215)]
+		[InlineData("LongBlob", 67108864)]
 		public async Task InsertLargeBlobAsync(string column, int size)
 		{
+			// verify that this amount of data can be sent to MySQL successfully
+			var maxAllowedPacket = (await m_database.Connection.QueryAsync<int>("select @@max_allowed_packet").ConfigureAwait(false)).Single();
+			if (maxAllowedPacket < size)
+				return; // TODO: Use [SkippableFact]
+
 			var data = new byte[size];
 			Random random = new Random(size);
 			random.NextBytes(data);
@@ -493,14 +500,15 @@ namespace SideBySide
 		[Theory]
 		[InlineData("TinyBlob", 255)]
 		[InlineData("Blob", 65535)]
-#if false
-		// MySQL has a default max_allowed_packet size of 4MB; without changing the server configuration, it's impossible
-		// to send more than 4MB of data.
 		[InlineData("MediumBlob", 16777215)]
 		[InlineData("LongBlob", 67108864)]
-#endif
 		public void InsertLargeBlobSync(string column, int size)
 		{
+			// verify that this amount of data can be sent to MySQL successfully
+			var maxAllowedPacket = m_database.Connection.Query<int>("select @@max_allowed_packet").Single();
+			if (maxAllowedPacket < size)
+				return; // TODO: Use [SkippableFact]
+
 			var data = new byte[size];
 			Random random = new Random(size);
 			random.NextBytes(data);

--- a/tests/SideBySide.New/DataTypes.cs
+++ b/tests/SideBySide.New/DataTypes.cs
@@ -474,9 +474,7 @@ namespace SideBySide
 			if (maxAllowedPacket < size)
 				return; // TODO: Use [SkippableFact]
 
-			var data = new byte[size];
-			Random random = new Random(size);
-			random.NextBytes(data);
+			var data = CreateByteArray(size);
 
 			long lastInsertId;
 			using (var cmd = new MySqlCommand(Invariant($"insert into datatypes.blobs(`{column}`) values(?)"), m_database.Connection)
@@ -509,9 +507,7 @@ namespace SideBySide
 			if (maxAllowedPacket < size)
 				return; // TODO: Use [SkippableFact]
 
-			var data = new byte[size];
-			Random random = new Random(size);
-			random.NextBytes(data);
+			var data = CreateByteArray(size);
 
 			long lastInsertId;
 			using (var cmd = new MySqlCommand(Invariant($"insert into datatypes.blobs(`{column}`) values(?)"), m_database.Connection)
@@ -530,6 +526,19 @@ namespace SideBySide
 			}
 
 			m_database.Connection.Execute(Invariant($"delete from datatypes.blobs where rowid = {lastInsertId}"));
+		}
+
+		private static byte[] CreateByteArray(int size)
+		{
+			var data = new byte[size];
+			Random random = new Random(size);
+			random.NextBytes(data);
+
+			// ensure each byte value is used at least once
+			for (int i = 0; i < Math.Min(255, size); i++)
+				data[i] = (byte) i;
+
+			return data;
 		}
 
 		[Theory]

--- a/tests/SideBySide.New/DataTypesFixture.cs
+++ b/tests/SideBySide.New/DataTypesFixture.cs
@@ -160,7 +160,11 @@ values
     '33221100-5544-7766-8899-aabbccddeeff', X'00112233445566778899AABBCCDDEEFF'),
   ('{33221100-5544-7766-8899-aabbccddeeff}', '{33221100-5544-7766-8899-aabbccddeeff}',
     '{33221100-5544-7766-8899-aabbccddeeff}', X'00112233445566778899AABBCCDDEEFF');
+");
 
+			if (TestUtilities.SupportsJson(Connection.ServerVersion))
+			{
+				Connection.Execute(@"
 create table datatypes.json_core (
   rowid integer not null primary key auto_increment,
   value json null
@@ -179,6 +183,7 @@ values
   ('{}'),
   ('{""a"": ""b""}');
 ");
+			}
 		}
 
 		protected override void Dispose(bool disposing)

--- a/tests/SideBySide.New/TestUtilities.cs
+++ b/tests/SideBySide.New/TestUtilities.cs
@@ -1,10 +1,26 @@
 ﻿using System;
 using System.Globalization;
+using Xunit;
 
 namespace SideBySide
 {
 	public class TestUtilities
 	{
+		/// <summary>
+		/// Asserts that two byte arrays are equal. This method is much faster than xUnit's <code>Assert.Equal</code>.
+		/// </summary>
+		/// <param name="expected">The expected byte array.</param>
+		/// <param name="actual">The actual byte array.</param>
+		public static void AssertEqual(byte[] expected, byte[] actual)
+		{
+			Assert.Equal(expected.Length, actual.Length);
+			for (var i = 0; i < expected.Length; i++)
+			{
+				if (expected[i] != actual[i])
+					Assert.Equal(expected[i], actual[i]);
+			}
+		}
+
 		public static Version ParseServerVersion(string serverVersion)
 		{
 			// copied from MySql.Data.MySqlClient.ServerVersion

--- a/tests/SideBySide.New/TestUtilities.cs
+++ b/tests/SideBySide.New/TestUtilities.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Globalization;
+
+namespace SideBySide
+{
+	public class TestUtilities
+	{
+		public static Version ParseServerVersion(string serverVersion)
+		{
+			// copied from MySql.Data.MySqlClient.ServerVersion
+
+			var last = 0;
+			var index = serverVersion.IndexOf('.', last);
+			var major = int.Parse(serverVersion.Substring(last, index - last), CultureInfo.InvariantCulture);
+			last = index + 1;
+
+			index = serverVersion.IndexOf('.', last);
+			var minor = int.Parse(serverVersion.Substring(last, index - last), CultureInfo.InvariantCulture);
+			last = index + 1;
+
+			do
+			{
+				index++;
+			} while (index < serverVersion.Length && serverVersion[index] >= '0' && serverVersion[index] <= '9');
+			var build = int.Parse(serverVersion.Substring(last, index - last), CultureInfo.InvariantCulture);
+
+			return new Version(major, minor, build);
+		}
+
+		public static bool SupportsJson(string serverVersion) =>
+			ParseServerVersion(serverVersion).CompareTo(new Version(5, 7)) >= 0;
+	}
+}

--- a/tests/SideBySide.New/project.json
+++ b/tests/SideBySide.New/project.json
@@ -7,7 +7,7 @@
 		"MySqlConnector": {
 			"target": "project"
 		},
-		"Dapper":  "1.50.0-*",
+		"Dapper":  "1.50.2",
 		"xunit": "2.2.0-beta2-build3300",
 		"dotnet-test-xunit": "2.2.0-preview2-build1029"
 	},


### PR DESCRIPTION
Enable all the tests to run on all builds, but ignore them at runtime if they will fail (e.g., due to packet size being bigger than what MySQL supports, or being run against a pre-5.7 server that doesn't support JSON).

TODO: Use [SkippableFact](https://github.com/AArnott/Xunit.SkippableFact) or a similar library to actually report the tests as skipped, rather than just not executing the code.