### PR TITLE
Support Synchronous connection string option. Fixes #91

### DIFF
--- a/src/MySqlConnector/MySqlClient/MySqlCommand.cs
+++ b/src/MySqlConnector/MySqlClient/MySqlCommand.cs
@@ -106,7 +106,7 @@ namespace MySql.Data.MySqlClient
 			ExecuteReaderAsync(behavior, IOBehavior.Synchronous, CancellationToken.None).GetAwaiter().GetResult();
 
 		public override Task<int> ExecuteNonQueryAsync(CancellationToken cancellationToken) =>
-			ExecuteNonQueryAsync(IOBehavior.Asynchronous, cancellationToken);
+			ExecuteNonQueryAsync(Connection.AsyncIOBehavior, cancellationToken);
 
 		internal async Task<int> ExecuteNonQueryAsync(IOBehavior ioBehavior, CancellationToken cancellationToken)
 		{
@@ -123,7 +123,7 @@ namespace MySql.Data.MySqlClient
 		}
 
 		public override Task<object> ExecuteScalarAsync(CancellationToken cancellationToken) =>
-			ExecuteScalarAsync(IOBehavior.Asynchronous, cancellationToken);
+			ExecuteScalarAsync(Connection.AsyncIOBehavior, cancellationToken);
 
 		internal async Task<object> ExecuteScalarAsync(IOBehavior ioBehavior, CancellationToken cancellationToken)
 		{
@@ -140,7 +140,7 @@ namespace MySql.Data.MySqlClient
 		}
 
 		protected override Task<DbDataReader> ExecuteDbDataReaderAsync(CommandBehavior behavior, CancellationToken cancellationToken) =>
-			ExecuteReaderAsync(behavior, IOBehavior.Asynchronous, cancellationToken);
+			ExecuteReaderAsync(behavior, Connection.AsyncIOBehavior, cancellationToken);
 
 		internal async Task<DbDataReader> ExecuteReaderAsync(CommandBehavior behavior, IOBehavior ioBehavior, CancellationToken cancellationToken)
 		{

--- a/src/MySqlConnector/MySqlClient/MySqlConnection.cs
+++ b/src/MySqlConnector/MySqlClient/MySqlConnection.cs
@@ -24,10 +24,10 @@ namespace MySql.Data.MySqlClient
 		public new MySqlTransaction BeginTransaction() => (MySqlTransaction) base.BeginTransaction();
 
 		public Task<MySqlTransaction> BeginTransactionAsync(CancellationToken cancellationToken = default(CancellationToken)) =>
-			BeginDbTransactionAsync(IsolationLevel.Unspecified, IOBehavior.Asynchronous, cancellationToken);
+			BeginDbTransactionAsync(IsolationLevel.Unspecified, AsyncIOBehavior, cancellationToken);
 
 		public Task<MySqlTransaction> BeginTransactionAsync(IsolationLevel isolationLevel, CancellationToken cancellationToken = default(CancellationToken)) =>
-			BeginDbTransactionAsync(isolationLevel, IOBehavior.Asynchronous, cancellationToken);
+			BeginDbTransactionAsync(isolationLevel, AsyncIOBehavior, cancellationToken);
 
 		protected override DbTransaction BeginDbTransaction(IsolationLevel isolationLevel) =>
 			BeginDbTransactionAsync(isolationLevel, IOBehavior.Synchronous, CancellationToken.None).GetAwaiter().GetResult();
@@ -91,7 +91,7 @@ namespace MySql.Data.MySqlClient
 		public override void Open() => OpenAsync(IOBehavior.Synchronous, CancellationToken.None).GetAwaiter().GetResult();
 
 		public override Task OpenAsync(CancellationToken cancellationToken) =>
-			OpenAsync(IOBehavior.Asynchronous, cancellationToken);
+			OpenAsync(AsyncIOBehavior, cancellationToken);
 
 		private async Task OpenAsync(IOBehavior ioBehavior, CancellationToken cancellationToken)
 		{
@@ -153,8 +153,8 @@ namespace MySql.Data.MySqlClient
 		public int ServerThread => m_session.ConnectionId;
 
 		public static void ClearPool(MySqlConnection connection) => ClearPoolAsync(connection, IOBehavior.Synchronous, CancellationToken.None).GetAwaiter().GetResult();
-		public static Task ClearPoolAsync(MySqlConnection connection) => ClearPoolAsync(connection, IOBehavior.Asynchronous, CancellationToken.None);
-		public static Task ClearPoolAsync(MySqlConnection connection, CancellationToken cancellationToken) => ClearPoolAsync(connection, IOBehavior.Asynchronous, cancellationToken);
+		public static Task ClearPoolAsync(MySqlConnection connection) => ClearPoolAsync(connection, connection.AsyncIOBehavior, CancellationToken.None);
+		public static Task ClearPoolAsync(MySqlConnection connection, CancellationToken cancellationToken) => ClearPoolAsync(connection, connection.AsyncIOBehavior, cancellationToken);
 		public static void ClearAllPools() => ConnectionPool.ClearPoolsAsync(IOBehavior.Synchronous, CancellationToken.None).GetAwaiter().GetResult();
 		public static Task ClearAllPoolsAsync() => ConnectionPool.ClearPoolsAsync(IOBehavior.Asynchronous, CancellationToken.None);
 		public static Task ClearAllPoolsAsync(CancellationToken cancellationToken) => ConnectionPool.ClearPoolsAsync(IOBehavior.Asynchronous, cancellationToken);
@@ -205,6 +205,7 @@ namespace MySql.Data.MySqlClient
 		internal bool AllowUserVariables => m_connectionStringBuilder.AllowUserVariables;
 		internal bool ConvertZeroDateTime => m_connectionStringBuilder.ConvertZeroDateTime;
 		internal bool OldGuids => m_connectionStringBuilder.OldGuids;
+		internal IOBehavior AsyncIOBehavior => m_connectionStringBuilder.Synchronous ? IOBehavior.Synchronous : IOBehavior.Asynchronous;
 
 		private async Task<MySqlSession> CreateSessionAsync(IOBehavior ioBehavior, CancellationToken cancellationToken)
 		{

--- a/src/MySqlConnector/MySqlClient/MySqlConnection.cs
+++ b/src/MySqlConnector/MySqlClient/MySqlConnection.cs
@@ -205,7 +205,7 @@ namespace MySql.Data.MySqlClient
 		internal bool AllowUserVariables => m_connectionStringBuilder.AllowUserVariables;
 		internal bool ConvertZeroDateTime => m_connectionStringBuilder.ConvertZeroDateTime;
 		internal bool OldGuids => m_connectionStringBuilder.OldGuids;
-		internal IOBehavior AsyncIOBehavior => m_connectionStringBuilder.Synchronous ? IOBehavior.Synchronous : IOBehavior.Asynchronous;
+		internal IOBehavior AsyncIOBehavior => m_connectionStringBuilder.ForceSynchronous ? IOBehavior.Synchronous : IOBehavior.Asynchronous;
 
 		private async Task<MySqlSession> CreateSessionAsync(IOBehavior ioBehavior, CancellationToken cancellationToken)
 		{

--- a/src/MySqlConnector/MySqlClient/MySqlConnectionStringBuilder.cs
+++ b/src/MySqlConnector/MySqlClient/MySqlConnectionStringBuilder.cs
@@ -118,6 +118,12 @@ namespace MySql.Data.MySqlClient
 			set { MySqlConnectionStringOption.UseAffectedRows.SetValue(this, value); }
 		}
 
+		public bool Synchronous
+		{
+			get { return MySqlConnectionStringOption.Synchronous.GetValue(this); }
+			set { MySqlConnectionStringOption.Synchronous.SetValue(this, value); }
+		}
+
 		public override bool ContainsKey(string key)
 		{
 			var option = MySqlConnectionStringOption.TryGetOptionForKey(key);
@@ -179,6 +185,7 @@ namespace MySql.Data.MySqlClient
 		public static readonly MySqlConnectionStringOption<uint> MinimumPoolSize;
 		public static readonly MySqlConnectionStringOption<uint> MaximumPoolSize;
 		public static readonly MySqlConnectionStringOption<bool> UseAffectedRows;
+		public static readonly MySqlConnectionStringOption<bool> Synchronous;
 
 		public static MySqlConnectionStringOption TryGetOptionForKey(string key)
 		{
@@ -281,6 +288,10 @@ namespace MySql.Data.MySqlClient
 			AddOption(UseAffectedRows = new MySqlConnectionStringOption<bool>(
 				keys: new[] { "Use Affected Rows", "UseAffectedRows" },
 				defaultValue: true));
+
+			AddOption(Synchronous = new MySqlConnectionStringOption<bool>(
+				keys: new[] { "Synchronous" },
+				defaultValue: false));
 		}
 
 		static readonly Dictionary<string, MySqlConnectionStringOption> s_options;

--- a/src/MySqlConnector/MySqlClient/MySqlConnectionStringBuilder.cs
+++ b/src/MySqlConnector/MySqlClient/MySqlConnectionStringBuilder.cs
@@ -118,10 +118,10 @@ namespace MySql.Data.MySqlClient
 			set { MySqlConnectionStringOption.UseAffectedRows.SetValue(this, value); }
 		}
 
-		public bool Synchronous
+		public bool ForceSynchronous
 		{
-			get { return MySqlConnectionStringOption.Synchronous.GetValue(this); }
-			set { MySqlConnectionStringOption.Synchronous.SetValue(this, value); }
+			get { return MySqlConnectionStringOption.ForceSynchronous.GetValue(this); }
+			set { MySqlConnectionStringOption.ForceSynchronous.SetValue(this, value); }
 		}
 
 		public override bool ContainsKey(string key)
@@ -185,7 +185,7 @@ namespace MySql.Data.MySqlClient
 		public static readonly MySqlConnectionStringOption<uint> MinimumPoolSize;
 		public static readonly MySqlConnectionStringOption<uint> MaximumPoolSize;
 		public static readonly MySqlConnectionStringOption<bool> UseAffectedRows;
-		public static readonly MySqlConnectionStringOption<bool> Synchronous;
+		public static readonly MySqlConnectionStringOption<bool> ForceSynchronous;
 
 		public static MySqlConnectionStringOption TryGetOptionForKey(string key)
 		{
@@ -289,8 +289,8 @@ namespace MySql.Data.MySqlClient
 				keys: new[] { "Use Affected Rows", "UseAffectedRows" },
 				defaultValue: true));
 
-			AddOption(Synchronous = new MySqlConnectionStringOption<bool>(
-				keys: new[] { "Synchronous" },
+			AddOption(ForceSynchronous = new MySqlConnectionStringOption<bool>(
+				keys: new[] { "ForceSynchronous" },
 				defaultValue: false));
 		}
 

--- a/src/MySqlConnector/MySqlClient/MySqlDataReader.cs
+++ b/src/MySqlConnector/MySqlClient/MySqlDataReader.cs
@@ -16,7 +16,7 @@ namespace MySql.Data.MySqlClient
 			NextResultAsync(IOBehavior.Synchronous, CancellationToken.None).GetAwaiter().GetResult();
 
 		public override Task<bool> NextResultAsync(CancellationToken cancellationToken) =>
-			NextResultAsync(IOBehavior.Asynchronous, cancellationToken);
+			NextResultAsync(m_command.Connection.AsyncIOBehavior, cancellationToken);
 
 		internal async Task<bool> NextResultAsync(IOBehavior ioBehavior, CancellationToken cancellationToken)
 		{
@@ -43,7 +43,7 @@ namespace MySql.Data.MySqlClient
 		}
 
 		public override Task<bool> ReadAsync(CancellationToken cancellationToken) =>
-			ReadAsync(IOBehavior.Asynchronous, cancellationToken);
+			ReadAsync(m_command.Connection.AsyncIOBehavior, cancellationToken);
 
 		internal Task<bool> ReadAsync(IOBehavior ioBehavior, CancellationToken cancellationToken)
 		{

--- a/src/MySqlConnector/MySqlClient/MySqlTransaction.cs
+++ b/src/MySqlConnector/MySqlClient/MySqlTransaction.cs
@@ -13,7 +13,7 @@ namespace MySql.Data.MySqlClient
 			CommitAsync(IOBehavior.Synchronous, CancellationToken.None).GetAwaiter().GetResult();
 
 		public Task CommitAsync(CancellationToken cancellationToken = default(CancellationToken)) =>
-			CommitAsync(IOBehavior.Asynchronous, cancellationToken);
+			CommitAsync(m_connection.AsyncIOBehavior, cancellationToken);
 
 		internal async Task CommitAsync(IOBehavior ioBehavior, CancellationToken cancellationToken)
 		{
@@ -42,7 +42,7 @@ namespace MySql.Data.MySqlClient
 			RollbackAsync(IOBehavior.Synchronous, CancellationToken.None).GetAwaiter().GetResult();
 
 		public Task RollbackAsync(CancellationToken cancellationToken = default(CancellationToken)) =>
-			RollbackAsync(IOBehavior.Asynchronous, cancellationToken);
+			RollbackAsync(m_connection.AsyncIOBehavior, cancellationToken);
 
 		internal async Task RollbackAsync(IOBehavior ioBehavior, CancellationToken cancellationToken)
 		{

--- a/tests/MySqlConnector.Tests/MySqlConnectionStringBuilderTests.cs
+++ b/tests/MySqlConnector.Tests/MySqlConnectionStringBuilderTests.cs
@@ -35,12 +35,21 @@ namespace MySql.Data.Tests
 			Assert.Equal("", csb.Server);
 			Assert.Equal(false, csb.UseCompression);
 			Assert.Equal("", csb.UserID);
+#if !BASELINE
+			Assert.Equal(false, csb.Synchronous);
+#endif
 		}
 
 		[Fact]
 		public void ParseConnectionString()
 		{
-			var csb = new MySqlConnectionStringBuilder { ConnectionString = "Data Source=db-server;Port=1234;Uid=username;pwd=Pass1234;Initial Catalog=schema_name;Allow User Variables=true;Character Set=latin1;Convert Zero Datetime=true;Pooling=no;OldGuids=true;Compress=true;ConnectionReset=false;minpoolsize=5;maxpoolsize=15;persistsecurityinfo=yes;useaffectedrows=false;connect timeout=30" };
+			var csb = new MySqlConnectionStringBuilder
+			{
+				ConnectionString = "Data Source=db-server;Port=1234;Uid=username;pwd=Pass1234;Initial Catalog=schema_name;Allow User Variables=true;Character Set=latin1;Convert Zero Datetime=true;Pooling=no;OldGuids=true;Compress=true;ConnectionReset=false;minpoolsize=5;maxpoolsize=15;persistsecurityinfo=yes;useaffectedrows=false;connect timeout=30"
+#if !BASELINE
+					+ ";synchronous=true"
+#endif
+			};
 			Assert.Equal(true, csb.AllowUserVariables);
 			Assert.Equal("latin1", csb.CharacterSet);
 			Assert.Equal(false, csb.ConnectionReset);
@@ -58,6 +67,9 @@ namespace MySql.Data.Tests
 			Assert.Equal(false, csb.UseAffectedRows);
 			Assert.Equal(true, csb.UseCompression);
 			Assert.Equal("username", csb.UserID);
+#if !BASELINE
+			Assert.Equal(true, csb.Synchronous);
+#endif
 		}
 
 #if !BASELINE

--- a/tests/MySqlConnector.Tests/MySqlConnectionStringBuilderTests.cs
+++ b/tests/MySqlConnector.Tests/MySqlConnectionStringBuilderTests.cs
@@ -36,7 +36,7 @@ namespace MySql.Data.Tests
 			Assert.Equal(false, csb.UseCompression);
 			Assert.Equal("", csb.UserID);
 #if !BASELINE
-			Assert.Equal(false, csb.Synchronous);
+			Assert.Equal(false, csb.ForceSynchronous);
 #endif
 		}
 
@@ -47,7 +47,7 @@ namespace MySql.Data.Tests
 			{
 				ConnectionString = "Data Source=db-server;Port=1234;Uid=username;pwd=Pass1234;Initial Catalog=schema_name;Allow User Variables=true;Character Set=latin1;Convert Zero Datetime=true;Pooling=no;OldGuids=true;Compress=true;ConnectionReset=false;minpoolsize=5;maxpoolsize=15;persistsecurityinfo=yes;useaffectedrows=false;connect timeout=30"
 #if !BASELINE
-					+ ";synchronous=true"
+					+ ";forcesynchronous=true"
 #endif
 			};
 			Assert.Equal(true, csb.AllowUserVariables);
@@ -68,7 +68,7 @@ namespace MySql.Data.Tests
 			Assert.Equal(true, csb.UseCompression);
 			Assert.Equal("username", csb.UserID);
 #if !BASELINE
-			Assert.Equal(true, csb.Synchronous);
+			Assert.Equal(true, csb.ForceSynchronous);
 #endif
 		}
 


### PR DESCRIPTION
If true, even Async methods run synchronously.

Theoretical benefits:
* Compare performance difference between sync and async without changing calling code.
* Better call stacks when debugging.

The setting has basic unit testing but I wasn't sure how to reliably test the change in behavior.