### PR TITLE
ssl connection string options

### DIFF
--- a/src/MySqlConnector/MySqlClient/MySqlConnectionStringBuilder.cs
+++ b/src/MySqlConnector/MySqlClient/MySqlConnectionStringBuilder.cs
@@ -5,6 +5,14 @@ using System.Globalization;
 
 namespace MySql.Data.MySqlClient
 {
+	public enum SslMode
+	{
+		None,
+		Required,
+		VerifyCa,
+		VerifyFull,
+	}
+
 	public sealed class MySqlConnectionStringBuilder : DbConnectionStringBuilder
 	{
 		public MySqlConnectionStringBuilder()
@@ -80,6 +88,24 @@ namespace MySql.Data.MySqlClient
 		{
 			get { return MySqlConnectionStringOption.UseCompression.GetValue(this); }
 			set { MySqlConnectionStringOption.UseCompression.SetValue(this, value); }
+		}
+
+		public SslMode SslMode
+		{
+			get { return MySqlConnectionStringOption.SslMode.GetValue(this); }
+			set { MySqlConnectionStringOption.SslMode.SetValue(this, value); }
+		}
+
+		public string CertificateFile
+		{
+			get { return MySqlConnectionStringOption.CertificateFile.GetValue(this); }
+			set { MySqlConnectionStringOption.CertificateFile.SetValue(this, value); }
+		}
+
+		public string CertificatePassword
+		{
+			get { return MySqlConnectionStringOption.CertificatePassword.GetValue(this); }
+			set { MySqlConnectionStringOption.CertificatePassword.SetValue(this, value); }
 		}
 
 		public bool Pooling
@@ -179,6 +205,9 @@ namespace MySql.Data.MySqlClient
 		public static readonly MySqlConnectionStringOption<bool> OldGuids;
 		public static readonly MySqlConnectionStringOption<bool> PersistSecurityInfo;
 		public static readonly MySqlConnectionStringOption<bool> UseCompression;
+		public static readonly MySqlConnectionStringOption<SslMode> SslMode;
+		public static readonly MySqlConnectionStringOption<string> CertificateFile;
+		public static readonly MySqlConnectionStringOption<string> CertificatePassword;
 		public static readonly MySqlConnectionStringOption<bool> Pooling;
 		public static readonly MySqlConnectionStringOption<bool> ConnectionReset;
 		public static readonly MySqlConnectionStringOption<uint> ConnectionTimeout;
@@ -265,6 +294,18 @@ namespace MySql.Data.MySqlClient
 				keys: new[] { "Compress", "Use Compression", "UseCompression" },
 				defaultValue: false));
 
+			AddOption(CertificateFile = new MySqlConnectionStringOption<string>(
+				keys: new[] { "CertificateFile", "Certificate File" },
+				defaultValue: ""));
+
+			AddOption(CertificatePassword = new MySqlConnectionStringOption<string>(
+				keys: new[] { "CertificatePassword", "Certificate Password" },
+				defaultValue: ""));
+
+			AddOption(SslMode = new MySqlConnectionStringOption<SslMode>(
+				keys: new[] { "SSL Mode", "SslMode" },
+				defaultValue: MySqlClient.SslMode.None));
+
 			AddOption(Pooling = new MySqlConnectionStringOption<bool>(
 				keys: new[] { "Pooling" },
 				defaultValue: true));
@@ -332,6 +373,16 @@ namespace MySql.Data.MySqlClient
 					return (T) (object) true;
 				if (string.Equals((string) objectValue, "no", StringComparison.OrdinalIgnoreCase))
 					return (T) (object) false;
+			}
+
+			if (typeof(T) == typeof(SslMode) && objectValue is string)
+			{
+				foreach (var val in Enum.GetValues(typeof(T)))
+				{
+					if (string.Equals((string) objectValue, val.ToString(), StringComparison.OrdinalIgnoreCase))
+						return (T) val;
+				}
+				throw new InvalidOperationException("Value '{0}' not supported for option '{1}'.".FormatInvariant(objectValue, typeof(T).Name));
 			}
 
 			return (T) Convert.ChangeType(objectValue, typeof(T), CultureInfo.InvariantCulture);

--- a/tests/MySqlConnector.Tests/MySqlConnectionStringBuilderTests.cs
+++ b/tests/MySqlConnector.Tests/MySqlConnectionStringBuilderTests.cs
@@ -35,6 +35,9 @@ namespace MySql.Data.Tests
 			Assert.Equal("", csb.Server);
 			Assert.Equal(false, csb.UseCompression);
 			Assert.Equal("", csb.UserID);
+			Assert.Equal(SslMode.None, csb.SslMode);
+			Assert.Equal("", csb.CertificateFile);
+			Assert.Equal("", csb.CertificatePassword);
 #if !BASELINE
 			Assert.Equal(false, csb.ForceSynchronous);
 #endif
@@ -45,7 +48,7 @@ namespace MySql.Data.Tests
 		{
 			var csb = new MySqlConnectionStringBuilder
 			{
-				ConnectionString = "Data Source=db-server;Port=1234;Uid=username;pwd=Pass1234;Initial Catalog=schema_name;Allow User Variables=true;Character Set=latin1;Convert Zero Datetime=true;Pooling=no;OldGuids=true;Compress=true;ConnectionReset=false;minpoolsize=5;maxpoolsize=15;persistsecurityinfo=yes;useaffectedrows=false;connect timeout=30"
+				ConnectionString = "Data Source=db-server;Port=1234;Uid=username;pwd=Pass1234;Initial Catalog=schema_name;Allow User Variables=true;Character Set=latin1;Convert Zero Datetime=true;Pooling=no;OldGuids=true;Compress=true;ConnectionReset=false;minpoolsize=5;maxpoolsize=15;persistsecurityinfo=yes;useaffectedrows=false;connect timeout=30;ssl mode=verifyca;certificate file=file.pfx;certificate password=Pass1234"
 #if !BASELINE
 					+ ";forcesynchronous=true"
 #endif
@@ -67,6 +70,9 @@ namespace MySql.Data.Tests
 			Assert.Equal(false, csb.UseAffectedRows);
 			Assert.Equal(true, csb.UseCompression);
 			Assert.Equal("username", csb.UserID);
+			Assert.Equal(SslMode.VerifyCa, csb.SslMode);
+			Assert.Equal("file.pfx", csb.CertificateFile);
+			Assert.Equal("Pass1234", csb.CertificatePassword);
 #if !BASELINE
 			Assert.Equal(true, csb.ForceSynchronous);
 #endif
@@ -91,6 +97,13 @@ namespace MySql.Data.Tests
 				UseAffectedRows = false,
 			};
 			Assert.Throws<NotSupportedException>(() => new MySqlConnection(csb.ConnectionString));
+		}
+
+		[Fact]
+		public void SslModePreferredInvalidOperation()
+		{
+			var csb = new MySqlConnectionStringBuilder("ssl mode=preferred;");
+			Assert.Throws<InvalidOperationException>(() => csb.SslMode);
 		}
 #endif
 	}


### PR DESCRIPTION
- Implements connection string options for #88 
- Adds an enumeration check for MySqlConnectionStringBuilder, needed for `SslMode`