### PR TITLE
Fix SslMode API.

### DIFF
--- a/src/MySqlConnector/MySqlClient/ConnectionPool.cs
+++ b/src/MySqlConnector/MySqlClient/ConnectionPool.cs
@@ -138,7 +138,7 @@ namespace MySql.Data.MySqlClient
 				await pool.ClearAsync(ioBehavior, cancellationToken).ConfigureAwait(false);
 		}
 
-		private ConnectionPool(IEnumerable<string> servers, int port, string userId, string password, string database, SslMode sslMode,
+		private ConnectionPool(IEnumerable<string> servers, int port, string userId, string password, string database, MySqlSslMode sslMode,
 			string certificateFile, string certificatePassword, bool resetConnections, int minimumSize, int maximumSize)
 		{
 			m_servers = servers;
@@ -169,7 +169,7 @@ namespace MySql.Data.MySqlClient
 		readonly string m_userId;
 		readonly string m_password;
 		readonly string m_database;
-		readonly SslMode m_sslMode;
+		readonly MySqlSslMode m_sslMode;
 		readonly string m_certificateFile;
 		readonly string m_certificatePassword;
 		readonly bool m_resetConnections;

--- a/src/MySqlConnector/MySqlClient/MySqlConnectionStringBuilder.cs
+++ b/src/MySqlConnector/MySqlClient/MySqlConnectionStringBuilder.cs
@@ -5,14 +5,6 @@ using System.Globalization;
 
 namespace MySql.Data.MySqlClient
 {
-	public enum SslMode
-	{
-		None,
-		Required,
-		VerifyCa,
-		VerifyFull,
-	}
-
 	public sealed class MySqlConnectionStringBuilder : DbConnectionStringBuilder
 	{
 		public MySqlConnectionStringBuilder()
@@ -90,7 +82,7 @@ namespace MySql.Data.MySqlClient
 			set { MySqlConnectionStringOption.UseCompression.SetValue(this, value); }
 		}
 
-		public SslMode SslMode
+		public MySqlSslMode SslMode
 		{
 			get { return MySqlConnectionStringOption.SslMode.GetValue(this); }
 			set { MySqlConnectionStringOption.SslMode.SetValue(this, value); }
@@ -205,7 +197,7 @@ namespace MySql.Data.MySqlClient
 		public static readonly MySqlConnectionStringOption<bool> OldGuids;
 		public static readonly MySqlConnectionStringOption<bool> PersistSecurityInfo;
 		public static readonly MySqlConnectionStringOption<bool> UseCompression;
-		public static readonly MySqlConnectionStringOption<SslMode> SslMode;
+		public static readonly MySqlConnectionStringOption<MySqlSslMode> SslMode;
 		public static readonly MySqlConnectionStringOption<string> CertificateFile;
 		public static readonly MySqlConnectionStringOption<string> CertificatePassword;
 		public static readonly MySqlConnectionStringOption<bool> Pooling;
@@ -296,15 +288,15 @@ namespace MySql.Data.MySqlClient
 
 			AddOption(CertificateFile = new MySqlConnectionStringOption<string>(
 				keys: new[] { "CertificateFile", "Certificate File" },
-				defaultValue: ""));
+				defaultValue: null));
 
 			AddOption(CertificatePassword = new MySqlConnectionStringOption<string>(
 				keys: new[] { "CertificatePassword", "Certificate Password" },
-				defaultValue: ""));
+				defaultValue: null));
 
-			AddOption(SslMode = new MySqlConnectionStringOption<SslMode>(
+			AddOption(SslMode = new MySqlConnectionStringOption<MySqlSslMode>(
 				keys: new[] { "SSL Mode", "SslMode" },
-				defaultValue: MySqlClient.SslMode.None));
+				defaultValue: MySqlSslMode.None));
 
 			AddOption(Pooling = new MySqlConnectionStringOption<bool>(
 				keys: new[] { "Pooling" },
@@ -375,7 +367,7 @@ namespace MySql.Data.MySqlClient
 					return (T) (object) false;
 			}
 
-			if (typeof(T) == typeof(SslMode) && objectValue is string)
+			if (typeof(T) == typeof(MySqlSslMode) && objectValue is string)
 			{
 				foreach (var val in Enum.GetValues(typeof(T)))
 				{

--- a/src/MySqlConnector/MySqlClient/MySqlSslMode.cs
+++ b/src/MySqlConnector/MySqlClient/MySqlSslMode.cs
@@ -1,0 +1,28 @@
+﻿namespace MySql.Data.MySqlClient
+{
+	/// <summary>
+	/// SSL connection options.
+	/// </summary>
+	public enum MySqlSslMode
+	{
+		/// <summary>
+		/// Do not use SSL. This is the default.
+		/// </summary>
+		None,
+
+		/// <summary>
+		/// Always use SSL. Deny connection if server does not support SSL.
+		/// </summary>
+		Required,
+
+		/// <summary>
+		///  Always use SSL. Validate the Certificate Authority but tolerate name mismatch.
+		/// </summary>
+		VerifyCA,
+
+		/// <summary>
+		/// Always use SSL. Fail if the host name is not correct.
+		/// </summary>
+		VerifyFull,
+	}
+}

--- a/src/MySqlConnector/Serialization/MySqlSession.cs
+++ b/src/MySqlConnector/Serialization/MySqlSession.cs
@@ -72,7 +72,7 @@ namespace MySql.Data.Serialization
 		}
 
 		public async Task ConnectAsync(IEnumerable<string> hosts, int port, string userId, string password, string database,
-			SslMode sslMode, string certificateFile, string certificatePassword, IOBehavior ioBehavior, CancellationToken cancellationToken)
+			MySqlSslMode sslMode, string certificateFile, string certificatePassword, IOBehavior ioBehavior, CancellationToken cancellationToken)
 		{
 			var connected = await OpenSocketAsync(hosts, port, ioBehavior, cancellationToken).ConfigureAwait(false);
 			if (!connected)
@@ -87,7 +87,7 @@ namespace MySql.Data.Serialization
 			ConnectionId = initialHandshake.ConnectionId;
 			AuthPluginData = initialHandshake.AuthPluginData;
 
-			if (sslMode != SslMode.None)
+			if (sslMode != MySqlSslMode.None)
 			{
 				X509Certificate2 certificate;
 				try
@@ -112,9 +112,9 @@ namespace MySql.Data.Serialization
 						case SslPolicyErrors.None:
 							return true;
 						case SslPolicyErrors.RemoteCertificateNameMismatch:
-							return sslMode != SslMode.VerifyFull;
+							return sslMode != MySqlSslMode.VerifyFull;
 						default:
-							return sslMode == SslMode.Required;
+							return sslMode == MySqlSslMode.Required;
 					}
 				};
 
@@ -128,7 +128,7 @@ namespace MySql.Data.Serialization
 				if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
 					sslProtocols |= SslProtocols.Tls12;
 
-				var checkCertificateRevocation = sslMode == SslMode.VerifyFull;
+				var checkCertificateRevocation = sslMode == MySqlSslMode.VerifyFull;
 
 				var initSsl = new PayloadData(new ArraySegment<byte>(HandshakeResponse41Packet.InitSsl(database)));
 				await SendReplyAsync(initSsl, ioBehavior, cancellationToken).ConfigureAwait(false);

--- a/tests/MySqlConnector.Tests/MySqlConnectionStringBuilderTests.cs
+++ b/tests/MySqlConnector.Tests/MySqlConnectionStringBuilderTests.cs
@@ -35,9 +35,14 @@ namespace MySql.Data.Tests
 			Assert.Equal("", csb.Server);
 			Assert.Equal(false, csb.UseCompression);
 			Assert.Equal("", csb.UserID);
-			Assert.Equal(SslMode.None, csb.SslMode);
-			Assert.Equal("", csb.CertificateFile);
-			Assert.Equal("", csb.CertificatePassword);
+#if BASELINE
+			Assert.Equal(MySqlSslMode.Prefered, csb.SslMode);
+#else
+			// this library doesn't support MySQL's "Preferred" option
+			Assert.Equal(MySqlSslMode.None, csb.SslMode);
+#endif
+			Assert.Equal(null, csb.CertificateFile);
+			Assert.Equal(null, csb.CertificatePassword);
 #if !BASELINE
 			Assert.Equal(false, csb.ForceSynchronous);
 #endif
@@ -70,7 +75,7 @@ namespace MySql.Data.Tests
 			Assert.Equal(false, csb.UseAffectedRows);
 			Assert.Equal(true, csb.UseCompression);
 			Assert.Equal("username", csb.UserID);
-			Assert.Equal(SslMode.VerifyCa, csb.SslMode);
+			Assert.Equal(MySqlSslMode.VerifyCA, csb.SslMode);
 			Assert.Equal("file.pfx", csb.CertificateFile);
 			Assert.Equal("Pass1234", csb.CertificatePassword);
 #if !BASELINE


### PR DESCRIPTION
Change the `MySqlSslMode` enum name and `MySqlConnectionStringBuilder` default values for certificate file options to match MySql.Data.

This fixes an unnecessary API incompatibility between MySqlConnector and MySql.Data.